### PR TITLE
Create lambda-events module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,13 @@ val http4sVersion = "1.0.0-M24"
 lazy val root =
   project
     .in(file("."))
-    .aggregate(lambda.js, lambda.jvm, lambdaApiGatewayProxy.js, lambdaApiGatewayProxy.jvm)
+    .aggregate(
+      lambda.js,
+      lambda.jvm,
+      lambdaEvents.js,
+      lambdaEvents.jvm,
+      lambdaApiGatewayProxyHttp4s.js,
+      lambdaApiGatewayProxyHttp4s.jvm)
     .enablePlugins(NoPublishPlugin)
 
 lazy val lambda = crossProject(JSPlatform, JVMPlatform)
@@ -58,14 +64,23 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
     )
   )
 
-lazy val lambdaApiGatewayProxy = crossProject(JSPlatform, JVMPlatform)
+lazy val lambdaEvents = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
-  .in(file("lambda-api-gateway-proxy"))
+  .in(file("lambda-events"))
   .settings(
-    name := "feral-lambda-api-gateway-proxy",
+    name := "feral-lambda-events",
     libraryDependencies ++= Seq(
-      "org.http4s" %%% "http4s-core" % http4sVersion,
       "io.circe" %%% "circe-generic" % circeVersion
     )
   )
-  .dependsOn(lambda)
+
+lazy val lambdaApiGatewayProxyHttp4s = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("lambda-api-gateway-proxy-http4s"))
+  .settings(
+    name := "feral-lambda-api-gateway-proxy",
+    libraryDependencies ++= Seq(
+      "org.http4s" %%% "http4s-core" % http4sVersion
+    )
+  )
+  .dependsOn(lambda, lambdaEvents)

--- a/lambda-api-gateway-proxy-http4s/src/main/scala/feral/lambda/ApiGatewayProxyHttp4sLambda.scala
+++ b/lambda-api-gateway-proxy-http4s/src/main/scala/feral/lambda/ApiGatewayProxyHttp4sLambda.scala
@@ -15,10 +15,11 @@
  */
 
 package feral.lambda
-package apigatewayproxy
 
 import cats.effect.IO
 import cats.effect.Resource
+import feral.lambda.events.ApiGatewayProxyEventV2
+import feral.lambda.events.ApiGatewayProxyStructuredResultV2
 import fs2.Stream
 import org.http4s.Charset
 import org.http4s.ContextRequest
@@ -30,10 +31,8 @@ import org.http4s.Request
 import org.http4s.Response
 import org.http4s.Uri
 
-abstract class ApiGatewayProxyLambda
-    extends IOLambda[
-      ApiGatewayProxyEventV2,
-      ApiGatewayProxyStructuredResultV2] {
+abstract class ApiGatewayProxyHttp4sLambda
+    extends IOLambda[ApiGatewayProxyEventV2, ApiGatewayProxyStructuredResultV2] {
 
   def routes: Resource[IO, ContextRoutes[Context, IO]]
 

--- a/lambda-events/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
+++ b/lambda-events/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feral.lambda.apigatewayproxy
+package feral.lambda.events
 
 import io.circe.Decoder
 import io.circe.generic.auto._

--- a/lambda-events/src/main/scala/feral/lambda/events/ApiGatewayProxyResultV2.scala
+++ b/lambda-events/src/main/scala/feral/lambda/events/ApiGatewayProxyResultV2.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package feral.lambda.apigatewayproxy
+package feral.lambda.events
 
 import io.circe.Encoder
 import io.circe.generic.semiauto._


### PR DESCRIPTION
These events should be re-usable without requiring buy-in to e.g. an http4s-flavored lambda.