### PR TITLE
Create core module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,20 +34,32 @@ lazy val root =
   project
     .in(file("."))
     .aggregate(
+      core.js,
+      core.jvm,
       lambda.js,
       lambda.jvm,
       lambdaEvents.js,
       lambdaEvents.jvm,
       lambdaApiGatewayProxyHttp4s.js,
-      lambdaApiGatewayProxyHttp4s.jvm)
+      lambdaApiGatewayProxyHttp4s.jvm
+    )
     .enablePlugins(NoPublishPlugin)
+
+lazy val core = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(file("core"))
+  .settings(
+    name := "feral-core",
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-effect" % catsEffectVersion
+    )
+  )
 
 lazy val lambda = crossProject(JSPlatform, JVMPlatform)
   .in(file("lambda"))
   .settings(
     name := "feral-lambda",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect" % catsEffectVersion,
       "io.circe" %%% "circe-core" % circeVersion
     )
   )
@@ -63,6 +75,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
       "io.circe" %%% "circe-fs2" % "0.14.0"
     )
   )
+  .dependsOn(core)
 
 lazy val lambdaEvents = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)

--- a/core/src/main/scala/feral/IOSetup.scala
+++ b/core/src/main/scala/feral/IOSetup.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feral
+
+import cats.effect.unsafe.IORuntime
+import cats.effect.kernel.Resource
+import cats.effect.IO
+import cats.effect.kernel.Deferred
+import cats.syntax.all._
+
+private[feral] trait IOSetup {
+
+  protected def runtime: IORuntime = IORuntime.global
+
+  protected type Setup
+  protected def setup: Resource[IO, Setup] = Resource.pure(null.asInstanceOf[Setup])
+
+  private[feral] final lazy val setupMemo: IO[Setup] = {
+    val deferred = Deferred.unsafe[IO, Either[Throwable, Setup]]
+    setup
+      .attempt
+      .allocated
+      .flatTap {
+        case (setup, _) =>
+          deferred.complete(setup)
+      }
+      .unsafeRunAndForget()(runtime)
+    deferred.get.rethrow
+  }
+
+}


### PR DESCRIPTION
This is cherry-picked out of #4. Creates a core module containing `IOSetup` to abstract the one-time-resource-acquisition logic.