### PR TITLE
add tracing support with Natchez

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,8 @@ lazy val lambdaApiGatewayProxyHttp4s = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "feral-lambda-api-gateway-proxy-http4s",
     libraryDependencies ++= Seq(
-      "org.http4s" %%% "http4s-core" % http4sVersion
+      "org.http4s" %%% "http4s-core" % http4sVersion,
+      "org.tpolecat" %% "natchez-http4s" % "0.1.3",
     )
   )
   .dependsOn(lambda, lambdaEvents)

--- a/build.sbt
+++ b/build.sbt
@@ -38,6 +38,7 @@ val catsEffectVersion = "3.2.9"
 val circeVersion = "0.14.1"
 val fs2Version = "3.2.2"
 val http4sVersion = "0.23.6"
+val natchezVersion = "0.1.5"
 
 lazy val root =
   project
@@ -62,7 +63,9 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "feral-core",
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "cats-effect" % catsEffectVersion
+      "org.typelevel" %%% "cats-effect" % catsEffectVersion,
+      "org.tpolecat" %%% "natchez-core" % natchezVersion,
+      "org.tpolecat" %%% "natchez-noop" % natchezVersion, // TODO Rob needs to publish this for SJS
     )
   )
 
@@ -71,7 +74,8 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "feral-lambda",
     libraryDependencies ++= Seq(
-      "io.circe" %%% "circe-core" % circeVersion
+      "io.circe" %%% "circe-core" % circeVersion,
+//      "org.tpolecat" %%% "natchez-xray" % natchezVersion, // TODO uncomment when this is published
     )
   )
   .jsSettings(

--- a/core/src/main/scala/feral/IOSetup.scala
+++ b/core/src/main/scala/feral/IOSetup.scala
@@ -17,10 +17,12 @@
 package feral
 
 import cats.effect.unsafe.IORuntime
-import cats.effect.kernel.Resource
-import cats.effect.IO
-import cats.effect.kernel.Deferred
+import cats.effect.{Deferred, IO, Resource}
 import cats.syntax.all._
+import natchez.Span
+import natchez.noop.NoopSpan
+
+import scala.annotation.nowarn
 
 private[feral] trait IOSetup {
 
@@ -28,6 +30,10 @@ private[feral] trait IOSetup {
 
   protected type Setup
   protected def setup: Resource[IO, Setup] = Resource.pure(null.asInstanceOf[Setup])
+
+  @nowarn(value = "msg=parameter value name in method traceRootSpan is never used")
+  protected def traceRootSpan(name: String): Resource[IO, Span[IO]] =
+    Resource.pure(NoopSpan[IO]())
 
   private[feral] final lazy val setupMemo: IO[Setup] = {
     val deferred = Deferred.unsafe[IO, Either[Throwable, Setup]]

--- a/lambda-api-gateway-proxy-http4s/src/main/scala/feral/lambda/ApiGatewayProxyHttp4sLambda.scala
+++ b/lambda-api-gateway-proxy-http4s/src/main/scala/feral/lambda/ApiGatewayProxyHttp4sLambda.scala
@@ -22,6 +22,7 @@ import cats.effect.SyncIO
 import feral.lambda.events.ApiGatewayProxyEventV2
 import feral.lambda.events.ApiGatewayProxyStructuredResultV2
 import fs2.Stream
+import natchez.Trace
 import org.http4s.Charset
 import org.http4s.Header
 import org.http4s.Headers
@@ -47,7 +48,8 @@ abstract class ApiGatewayProxyHttp4sLambda
   override final def apply(
       event: ApiGatewayProxyEventV2,
       context: Context,
-      routes: HttpRoutes[IO]): IO[Some[ApiGatewayProxyStructuredResultV2]] =
+      routes: HttpRoutes[IO])(
+      implicit T: Trace[IO]): IO[Some[ApiGatewayProxyStructuredResultV2]] =
     for {
       method <- IO.fromEither(Method.fromString(event.requestContext.http.method))
       uri <- IO.fromEither(Uri.fromString(event.rawPath))

--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
@@ -33,15 +33,12 @@ import org.http4s.ember.client.EmberClientBuilder
 import java.io.{PrintWriter, StringWriter}
 
 trait CloudFormationCustomResource[F[_], Input, Output] {
-  def createResource(
-      event: CloudFormationCustomResourceRequest[Input],
-      context: Context): F[HandlerResponse[Output]]
-  def updateResource(
-      event: CloudFormationCustomResourceRequest[Input],
-      context: Context): F[HandlerResponse[Output]]
-  def deleteResource(
-      event: CloudFormationCustomResourceRequest[Input],
-      context: Context): F[HandlerResponse[Output]]
+  def createResource(event: CloudFormationCustomResourceRequest[Input], context: Context)(
+      implicit T: Trace[F]): F[HandlerResponse[Output]]
+  def updateResource(event: CloudFormationCustomResourceRequest[Input], context: Context)(
+      implicit T: Trace[F]): F[HandlerResponse[Output]]
+  def deleteResource(event: CloudFormationCustomResourceRequest[Input], context: Context)(
+      implicit T: Trace[F]): F[HandlerResponse[Output]]
 }
 
 abstract class CloudFormationCustomResourceHandler[Input: Decoder, Output: Encoder]

--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
@@ -16,17 +16,17 @@
 
 package feral.lambda.cloudformation
 
-import cats.effect._
-import cats.effect.kernel.Resource
+import cats.effect.{IO, Resource}
 import cats.syntax.all._
 import feral.lambda.cloudformation.CloudFormationCustomResourceHandler.stackTraceLines
 import feral.lambda.cloudformation.CloudFormationRequestType._
 import feral.lambda.{Context, IOLambda}
 import io.circe._
 import io.circe.syntax._
+import natchez.Trace
 import org.http4s.Method.POST
-import org.http4s.client.Client
 import org.http4s.circe._
+import org.http4s.client.Client
 import org.http4s.client.dsl.io._
 import org.http4s.ember.client.EmberClientBuilder
 
@@ -59,7 +59,7 @@ abstract class CloudFormationCustomResourceHandler[Input: Decoder, Output: Encod
   override def apply(
       event: CloudFormationCustomResourceRequest[Input],
       context: Context,
-      setup: Setup): IO[Option[Unit]] =
+      setup: Setup)(implicit T: Trace[IO]): IO[Option[Unit]] =
     (event.RequestType match {
       case CreateRequest => setup._2.createResource(event, context)
       case UpdateRequest => setup._2.updateResource(event, context)

--- a/lambda/shared/src/main/scala/feral/lambda/IOLambda.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/IOLambda.scala
@@ -18,8 +18,8 @@ package feral
 package lambda
 
 import cats.effect.IO
-import io.circe.Decoder
-import io.circe.Encoder
+import io.circe.{Decoder, Encoder}
+import natchez.Trace
 
 abstract class IOLambda[Event, Result](
     implicit private[lambda] val decoder: Decoder[Event],
@@ -27,5 +27,6 @@ abstract class IOLambda[Event, Result](
 ) extends IOLambdaPlatform[Event, Result]
     with IOSetup {
 
-  def apply(event: Event, context: Context, setup: Setup): IO[Option[Result]]
+  def apply(event: Event, context: Context, setup: Setup)(
+      implicit T: Trace[IO]): IO[Option[Result]]
 }

--- a/lambda/shared/src/main/scala/feral/lambda/XRayTracing.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/XRayTracing.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* TODO this file won't compile until these PRs are merged & published:
+ * https://github.com/christiankjaer/natchez/pull/1
+ * https://github.com/tpolecat/natchez/pull/427
+ */
+
+package feral.lambda
+
+import cats.effect.{IO, Resource}
+import feral.IOSetup
+import natchez.xray.{XRay, XRayEnvironment}
+import natchez.{EntryPoint, Span}
+
+trait XRayTracing extends IOSetup {
+  private def traceEntryPoint: Resource[IO, EntryPoint[IO]] =
+    Resource.eval(XRayEnvironment[IO].daemonAddress).flatMap {
+      case Some(addr) => XRay.entryPoint(addr)
+      case None => XRay.entryPoint()
+    }
+
+  override protected def traceRootSpan(name: String): Resource[IO, Span[IO]] =
+    Resource.eval(XRayEnvironment[IO].kernelFromEnvironment).flatMap { kernel =>
+      traceEntryPoint.flatMap(_.continueOrElseRoot(name, kernel))
+    }
+}


### PR DESCRIPTION
I've been using this with a locally published version of https://github.com/christiankjaer/natchez/pull/1 and https://github.com/tpolecat/natchez/pull/427 and it seems to work.

My thought is that we can bake in no-op tracing, and then the user can mix in a trait that implements tracing for their preferred backend. It doesn't compile here yet (because of the missing artifacts) but the `XRayTracing` trait is an example of how that could work. WDYT?