### PR TITLE
Pin ci to Node.js v14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
+      - name: Setup NodeJS v14 LTS
+        if: matrix.ci == 'ciJS'
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
       - name: Check that workflows are up to date
         run: sbt ++${{ matrix.scala }} githubWorkflowCheck
 

--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,14 @@ replaceCommandAlias(
   "; project /; headerCheckAll; scalafmtCheckAll; scalafmtSbtCheck; clean; testIfRelevant; mimaReportBinaryIssuesIfRelevant"
 )
 
+ThisBuild / githubWorkflowBuildPreamble +=
+  WorkflowStep.Use(
+    UseRef.Public("actions", "setup-node", "v2"),
+    name = Some("Setup NodeJS v14 LTS"),
+    params = Map("node-version" -> "14"),
+    cond = Some("matrix.ci == 'ciJS'")
+  )
+
 val catsEffectVersion = "3.2.9"
 val circeVersion = "0.14.1"
 val fs2Version = "3.2.2"


### PR DESCRIPTION
The default Node.js in GHA is being updated to v16:
- https://github.com/actions/virtual-environments/issues/4446

However, AWS will probably be stuck on v14 for at least some time:
- https://github.com/aws/aws-lambda-base-images/issues/14