### PR TITLE
Use AWS corretto JDKs in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,11 @@ jobs:
         os: [ubuntu-latest]
         scala: [3.1.0, 2.12.15, 2.13.7]
         java: [corretto@8, corretto@11]
+        exclude:
+          - scala: 3.1.0
+            java: corretto@11
+          - scala: 2.12.15
+            java: corretto@11
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  JABBA_INDEX: 'https://github.com/typelevel/jdk-index/raw/main/index.json'
 
 jobs:
   build:
@@ -23,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.1.0, 2.12.15, 2.13.7]
-        java: [adopt@1.8]
+        java: [corretto@8, corretto@11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -49,7 +50,6 @@ jobs:
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
       - name: Setup NodeJS v14 LTS
-        if: matrix.ci == 'ciJS'
         uses: actions/setup-node@v2
         with:
           node-version: 14

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,9 @@ ThisBuild / developers := List(
   Developer("djspiewak", "Daniel Spiewak", "@djspiewak", url("https://github.com/djspiewak"))
 )
 
+ThisBuild / githubWorkflowJavaVersions := List("corretto@8", "corretto@11")
+ThisBuild / githubWorkflowEnv += ("JABBA_INDEX" -> "https://github.com/typelevel/jdk-index/raw/main/index.json")
+
 replaceCommandAlias(
   "ci",
   "; project /; headerCheckAll; scalafmtCheckAll; scalafmtSbtCheck; clean; testIfRelevant; mimaReportBinaryIssuesIfRelevant"
@@ -38,8 +41,7 @@ ThisBuild / githubWorkflowBuildPreamble +=
   WorkflowStep.Use(
     UseRef.Public("actions", "setup-node", "v2"),
     name = Some("Setup NodeJS v14 LTS"),
-    params = Map("node-version" -> "14"),
-    cond = Some("matrix.ci == 'ciJS'")
+    params = Map("node-version" -> "14")
   )
 
 val catsEffectVersion = "3.2.9"

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,12 @@ ThisBuild / developers := List(
 
 ThisBuild / githubWorkflowJavaVersions := List("corretto@8", "corretto@11")
 ThisBuild / githubWorkflowEnv += ("JABBA_INDEX" -> "https://github.com/typelevel/jdk-index/raw/main/index.json")
+ThisBuild / githubWorkflowBuildMatrixExclusions ++= {
+  for {
+    scala <- (ThisBuild / crossScalaVersions).value.init
+    java <- (ThisBuild / githubWorkflowJavaVersions).value.tail
+  } yield MatrixExclude(Map("scala" -> scala, "java" -> java))
+}
 
 replaceCommandAlias(
   "ci",


### PR DESCRIPTION
These are the Java runtimes available for AWS Lambda according to https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html.

Special thanks to @vasilmkd for adding these to the Typelevel JDK index!