### PR TITLE
Export the JS lambda handler

### DIFF
--- a/lambda/js/src/main/scala/feral/lambda/IOLambdaPlatform.scala
+++ b/lambda/js/src/main/scala/feral/lambda/IOLambdaPlatform.scala
@@ -26,11 +26,18 @@ import scala.scalajs.js.|
 private[lambda] trait IOLambdaPlatform[Event, Result] {
   this: IOLambda[Event, Result] =>
 
-  // @JSExportTopLevel("handler") // TODO
-  final def handler(event: js.Any, context: facade.Context): js.Promise[js.Any | Unit] =
-    (for {
-      lambda <- setupMemo
-      event <- IO.fromEither(decodeJs[Event](event))
-      result <- lambda(event, Context.fromJS(context))
-    } yield result.map(_.asJsAny).orUndefined).unsafeToPromise()(runtime)
+  def main(args: Array[String]): Unit = {
+    val handlerName = getClass.getSimpleName.init
+    js.Dynamic.global.exports.updateDynamic(handlerName)(handlerFn)
+  }
+
+  private lazy val handlerFn
+      : js.Function2[js.Any, facade.Context, js.Promise[js.Any | Unit]] = {
+    (event: js.Any, context: facade.Context) =>
+      (for {
+        lambda <- setupMemo
+        event <- IO.fromEither(decodeJs[Event](event))
+        result <- lambda(event, Context.fromJS(context))
+      } yield result.map(_.asJsAny).orUndefined).unsafeToPromise()(runtime)
+  }
 }


### PR DESCRIPTION
This enables the handler function to be called from the Node.js lambda runtime. The name of the exported handler is the name of the object it is implemented in.