### PR TITLE
Seal LambdaEnv

### DIFF
--- a/lambda/shared/src/main/scala/feral/lambda/LambdaEnv.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/LambdaEnv.scala
@@ -28,7 +28,7 @@ import cats.kernel.Monoid
 import cats.syntax.all._
 import cats.~>
 
-trait LambdaEnv[F[_], Event] { outer =>
+sealed trait LambdaEnv[F[_], Event] { outer =>
   def event: F[Event]
   def context: F[Context[F]]
 


### PR DESCRIPTION
I'm actually not sure if we want to do this or not. Seems reasonable, esp. since we offer the `mapK` method anyway. So I'd rather seal it for now and have users complain with legit use-cases than leave it open and not know about the witchcraft going on 😆 