### PR TITLE
Rollback scalafmt to 2.4.4

### DIFF
--- a/lambda/shared/src/main/scala-2/feral/lambda/package.scala
+++ b/lambda/shared/src/main/scala-2/feral/lambda/package.scala
@@ -21,6 +21,7 @@ import io.circe.Encoder
 import scala.annotation.nowarn
 
 package object lambda {
+
   /**
    * Alias for `Nothing` which works better with type inference. Inspired by fs2, but inlined
    * here to avoid pulling in an otherwise-unnecessary dependency.

--- a/lambda/shared/src/main/scala/feral/lambda/TracedHandler.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/TracedHandler.scala
@@ -27,7 +27,8 @@ import natchez.Trace
 
 object TracedHandler {
 
-  def apply[Event, Result](entryPoint: EntryPoint[IO])(handler: Trace[IO] => IO[Option[Result]])(
+  def apply[Event, Result](entryPoint: EntryPoint[IO])(
+      handler: Trace[IO] => IO[Option[Result]])(
       implicit env: LambdaEnv[IO, Event],
       KS: KernelSource[Event]): IO[Option[Result]] = for {
     event <- env.event

--- a/lambda/shared/src/main/scala/feral/lambda/events/SQSEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SQSEvent.scala
@@ -105,7 +105,8 @@ object SQSRecordAttributes {
       messageDeduplicationId
     ))
 
-  implicit def kernelSource: KernelSource[SQSRecordAttributes] = a => Kernel(a.awsTraceHeader.map("X-Amzn-Trace-Id" -> _).toMap)
+  implicit def kernelSource: KernelSource[SQSRecordAttributes] = a =>
+    Kernel(a.awsTraceHeader.map("X-Amzn-Trace-Id" -> _).toMap)
 }
 
 sealed trait SQSMessageAttribute

--- a/lambda/shared/src/test/scala/feral/lambda/TracedHandlerSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/TracedHandlerSuite.scala
@@ -34,9 +34,7 @@ class TracedLambdaSuite {
     def ioEntryPoint: EntryPoint[IO] = ???
     def needsTrace[F[_]: Trace]: F[Option[INothing]] = ???
 
-    TracedHandler(ioEntryPoint) { implicit trace =>
-      needsTrace[IO]
-    }
+    TracedHandler(ioEntryPoint) { implicit trace => needsTrace[IO] }
 
     TracedHandler(ioEntryPoint, Kleisli[IO, Span[IO], Option[INothing]](???))
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.codecommit" % "sbt-spiewak-sonatype" % "0.22.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.4")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")


### PR DESCRIPTION
There seems to be a regression that prevents `shared/` sources from being formatted/checked in CI.