### PR TITLE
Add `IOLambdaSuite`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -139,7 +139,8 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
       "org.tpolecat" %%% "natchez-core" % natchezVersion,
       "io.circe" %%% "circe-scodec" % circeVersion,
       "org.scodec" %%% "scodec-bits" % "1.1.30",
-      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test
+      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test
     ),
     libraryDependencies ++= {
       if (isDotty.value) Nil
@@ -188,8 +189,7 @@ lazy val lambdaHttp4s = crossProject(JSPlatform, JVMPlatform)
   .settings(
     name := "feral-lambda-http4s",
     libraryDependencies ++= Seq(
-      "org.http4s" %%% "http4s-server" % http4sVersion,
-      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test
+      "org.http4s" %%% "http4s-server" % http4sVersion
     )
   )
   .settings(commonSettings)

--- a/lambda/shared/src/test/scala/feral/lambda/IOLambdaSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/IOLambdaSuite.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feral.lambda
+
+import cats.effect.IO
+import cats.effect.kernel.Resource
+import cats.syntax.all._
+import munit.CatsEffectSuite
+
+class IOLambdaSuite extends CatsEffectSuite {
+
+  test("handler is correctly installed") {
+    for {
+      allocationCounter <- IO.ref(0)
+      invokeCounter <- IO.ref(0)
+      lambda <- IO {
+        new IOLambda[String, String] {
+          def handler = Resource
+            .eval(allocationCounter.getAndUpdate(_ + 1))
+            .as(_.event.map(Some(_)) <* invokeCounter.getAndUpdate(_ + 1))
+        }
+      }
+      handler <- lambda.setupMemo
+      _ <- ('0' to 'z')
+        .map(_.toString)
+        .toList
+        .traverse(x => handler(x, mockContext).assertEquals(Some(x)))
+      _ <- allocationCounter.get.assertEquals(1)
+      _ <- invokeCounter.get.assertEquals(75)
+    } yield ()
+  }
+
+  def mockContext = new Context[IO]("", "", "", 0, "", "", "", None, None, IO.never)
+
+}


### PR DESCRIPTION
Seems like a good thing to test :) Tests the following:
1. The handler is installed exactly once
2. The lambda is invoked once per event
3. The events are not getting lost or mixed up due to misuse of `IOLocal`