### PR TITLE
Enable JS lambda handler name to be customized

### DIFF
--- a/lambda/js/src/main/scala/feral/lambda/IOLambdaPlatform.scala
+++ b/lambda/js/src/main/scala/feral/lambda/IOLambdaPlatform.scala
@@ -26,10 +26,10 @@ import scala.scalajs.js.|
 private[lambda] trait IOLambdaPlatform[Event, Result] {
   this: IOLambda[Event, Result] =>
 
-  def main(args: Array[String]): Unit = {
-    val handlerName = getClass.getSimpleName.init
+  final def main(args: Array[String]): Unit =
     js.Dynamic.global.exports.updateDynamic(handlerName)(handlerFn)
-  }
+
+  protected def handlerName: String = getClass.getSimpleName.init
 
   private lazy val handlerFn
       : js.Function2[js.Any, facade.Context, js.Promise[js.Any | Unit]] = {


### PR DESCRIPTION
Exposes the `handlerName` as an overriddable `def`. Keeps the default to the `object` name .

@kubukoz you can hard-code this to "handler" for your Netlify `IOFunction`.