### PR TITLE
Add support for `custom` field in `ClientContext`

### DIFF
--- a/lambda/js/src/main/scala/feral/lambda/ContextPlatform.scala
+++ b/lambda/js/src/main/scala/feral/lambda/ContextPlatform.scala
@@ -17,6 +17,8 @@
 package feral.lambda
 
 import cats.effect.Sync
+import io.circe.JsonObject
+import io.circe.scalajs._
 
 import scala.concurrent.duration._
 
@@ -52,7 +54,12 @@ private[lambda] trait ContextCompanionPlatform {
               clientContext.env.make,
               clientContext.env.model,
               clientContext.env.locale
-            )
+            ),
+            clientContext
+              .custom
+              .toOption
+              .flatMap(decodeJs[JsonObject](_).toOption)
+              .getOrElse(JsonObject.empty)
           )
         },
       Sync[F].delay(context.getRemainingTimeInMillis().millis)

--- a/lambda/js/src/main/scala/feral/lambda/facade/Context.scala
+++ b/lambda/js/src/main/scala/feral/lambda/facade/Context.scala
@@ -42,7 +42,7 @@ private[lambda] sealed trait CognitoIdentity extends js.Object {
 @js.native
 private[lambda] sealed trait ClientContext extends js.Object {
   def client: ClientContextClient = js.native
-  def Custom: js.Any = js.native
+  def custom: js.UndefOr[js.Any] = js.native
   def env: ClientContextEnv = js.native
 }
 

--- a/lambda/jvm/src/main/scala/feral/lambda/ContextPlatform.scala
+++ b/lambda/jvm/src/main/scala/feral/lambda/ContextPlatform.scala
@@ -18,8 +18,11 @@ package feral.lambda
 
 import cats.effect.Sync
 import com.amazonaws.services.lambda.runtime
+import io.circe.JsonObject
+import io.circe.jawn
 
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 private[lambda] trait ContextCompanionPlatform {
 
@@ -50,7 +53,11 @@ private[lambda] trait ContextCompanionPlatform {
             clientContext.getEnvironment().get("make"),
             clientContext.getEnvironment().get("model"),
             clientContext.getEnvironment().get("locale")
-          )
+          ),
+          JsonObject.fromIterable(clientContext.getCustom().asScala.view.flatMap {
+            case (k, v) =>
+              jawn.parse(v).toOption.map(k -> _)
+          })
         )
       },
       Sync[F].delay(context.getRemainingTimeInMillis().millis)

--- a/lambda/shared/src/main/scala/feral/lambda/Context.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/Context.scala
@@ -17,6 +17,7 @@
 package feral.lambda
 
 import cats.~>
+import io.circe.JsonObject
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -54,7 +55,8 @@ final class CognitoIdentity(
 
 final class ClientContext(
     val client: ClientContextClient,
-    val env: ClientContextEnv
+    val env: ClientContextEnv,
+    val custom: JsonObject
 )
 
 final class ClientContextClient(


### PR DESCRIPTION
By modelling it as a `JsonObject` and parsing/decoding it as such.

In fact, it seems the entirety of `ClientContext` is parsed from JSON in the Java and Node.js Lambda runtimes.
- https://github.com/aws/aws-lambda-java-libs/blob/4fe08f417a4f5b612bb8d88006da3341eb6d3e51/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/EventHandlerLoader.java#L109
- https://github.com/aws/aws-lambda-nodejs-runtime-interface-client/blob/c31c41ffe5f2f03ae9e8589b96f3b005e2bb8a4a/src/Runtime/InvokeContext.ts#L114