### PR TITLE
`publishLocal` for scripted tests directly from sbt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,6 @@ jobs:
             ~/Library/Caches/Coursier/v1
           key: ${{ runner.os }}-sbt-cache-v2-${{ hashFiles('**/*.sbt') }}-${{ hashFiles('project/build.properties') }}
 
-      - name: Publish local
-        if: matrix.scala == '2.12.15'
-        run: sbt ++${{ matrix.scala }} ++2.13.7 publishLocal
-
       - name: Setup NodeJS v14 LTS
         uses: actions/setup-node@v2
         with:

--- a/build.sbt
+++ b/build.sbt
@@ -54,12 +54,6 @@ ThisBuild / githubWorkflowGeneratedUploadSteps ~= { steps =>
   mkdirStep +: steps
 }
 
-ThisBuild / githubWorkflowBuildPreamble += WorkflowStep.Sbt(
-  List(s"++$Scala213", "publishLocal"),
-  name = Some("Publish local"),
-  cond = Some(s"matrix.scala == '$Scala212'")
-)
-
 ThisBuild / githubWorkflowBuild ~= { steps =>
   val ciStep = steps.headOption match {
     case Some(step @ WorkflowStep.Sbt(_, _, _, _, _, _)) =>
@@ -187,7 +181,8 @@ lazy val sbtLambda = project
     buildInfoKeys += organization,
     scriptedLaunchOpts := {
       scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
-    }
+    },
+    scripted := scripted.dependsOn(core.js / publishLocal, lambda.js / publishLocal).evaluated
   )
 
 lazy val lambdaHttp4s = crossProject(JSPlatform, JVMPlatform)


### PR DESCRIPTION
Instead of doing it externally. Simplifies the generated GHA workflow and works locally without doing the extra step manually.