### PR TITLE
use PUT instead of POST for CloudFormation Custom Resource responses…

### DIFF
--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
@@ -23,7 +23,7 @@ import cats.syntax.all._
 import feral.lambda.cloudformation.CloudFormationRequestType._
 import io.circe._
 import io.circe.syntax._
-import org.http4s.Method.POST
+import org.http4s.Method.PUT
 import org.http4s.circe._
 import org.http4s.client.Client
 import org.http4s.client.dsl.Http4sClientDsl
@@ -55,7 +55,7 @@ object CloudFormationCustomResource {
         case OtherRequestType(other) => illegalRequestType(other)
       }).attempt
         .map(_.fold(exceptionResponse(event)(_), successResponse(event)(_)))
-        .flatMap { resp => client.successful(POST(resp.asJson, event.ResponseURL)) }
+        .flatMap { resp => client.successful(PUT(resp.asJson, event.ResponseURL)) }
         .as(None)
     }
   }


### PR DESCRIPTION
… since that's what AWS expects.

From [Custom resource provider response fields](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html):

> For more information about uploading objects by using presigned URLs, see the related topic in the Amazon Simple Storage Service User Guide.

From [the Amazon Simple Storage Service User Guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/PresignedUrlUploadObject.html):

> When you create a presigned URL, you must provide your security credentials and then specify a bucket name, an object key, an HTTP method (PUT for uploading objects), and an expiration date and time. The presigned URLs are valid only for the specified duration. That is, you must start the action before the expiration date and time. If the action consists of multiple steps, such as a multipart upload, all steps must be started before the expiration, otherwise you will receive an error when Amazon S3 attempts to start a step with an expired URL.