### PR TITLE
fix some CloudFormation Custom Resource response issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,7 +175,6 @@ lazy val lambdaCloudFormationCustomResource = crossProject(JSPlatform, JVMPlatfo
       "org.typelevel" %%% "scalacheck-effect" % "1.0.3" % Test,
       "org.typelevel" %%% "scalacheck-effect-munit" % "1.0.3" % Test,
       "com.eed3si9n.expecty" %%% "expecty" % "0.15.4" % Test,
-      "io.circe" %%% "circe-optics" % "0.14.1" % Test,
       "io.circe" %%% "circe-literal" % "0.14.1" % Test,
       "io.circe" %%% "circe-testing" % "0.14.1" % Test
     )

--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,16 @@ lazy val lambdaCloudFormationCustomResource = crossProject(JSPlatform, JVMPlatfo
     libraryDependencies ++= Seq(
       "io.monix" %%% "newtypes-core" % "0.0.1",
       "org.http4s" %%% "http4s-client" % http4sVersion,
-      "org.http4s" %%% "http4s-circe" % http4sVersion
+      "org.http4s" %%% "http4s-circe" % http4sVersion,
+      "org.http4s" %%% "http4s-dsl" % http4sVersion % Test,
+      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test,
+      "org.typelevel" %%% "scalacheck-effect" % "1.0.3" % Test,
+      "org.typelevel" %%% "scalacheck-effect-munit" % "1.0.3" % Test,
+      "com.eed3si9n.expecty" %%% "expecty" % "0.15.4" % Test,
+      "io.circe" %%% "circe-optics" % "0.14.1" % Test,
+      "io.circe" %%% "circe-literal" % "0.14.1" % Test,
+      "io.circe" %%% "circe-testing" % "0.14.1" % Test
     )
   )
   .settings(commonSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ val http4sVersion = "0.23.7"
 val natchezVersion = "0.1.6"
 val munitVersion = "0.7.29"
 val munitCEVersion = "1.0.7"
+val scalacheckEffectVersion = "1.0.3"
 
 lazy val commonSettings = Seq(
   crossScalaVersions := Seq(Scala3, Scala213)
@@ -100,7 +101,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
       "io.circe" %%% "circe-scodec" % circeVersion,
       "org.scodec" %%% "scodec-bits" % "1.1.30",
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
-      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test
+      "org.typelevel" %%% "munit-cats-effect-3" % munitCEVersion % Test
     ),
     libraryDependencies ++= {
       if (tlIsScala3.value) Nil
@@ -171,12 +172,11 @@ lazy val lambdaCloudFormationCustomResource = crossProject(JSPlatform, JVMPlatfo
       "org.http4s" %%% "http4s-circe" % http4sVersion,
       "org.http4s" %%% "http4s-dsl" % http4sVersion % Test,
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
-      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test,
-      "org.typelevel" %%% "scalacheck-effect" % "1.0.3" % Test,
-      "org.typelevel" %%% "scalacheck-effect-munit" % "1.0.3" % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % munitCEVersion % Test,
+      "org.typelevel" %%% "scalacheck-effect" % scalacheckEffectVersion % Test,
+      "org.typelevel" %%% "scalacheck-effect-munit" % scalacheckEffectVersion % Test,
       "com.eed3si9n.expecty" %%% "expecty" % "0.15.4" % Test,
-      "io.circe" %%% "circe-literal" % "0.14.1" % Test,
-      "io.circe" %%% "circe-testing" % "0.14.1" % Test
+      "io.circe" %%% "circe-testing" % circeVersion % Test
     )
   )
   .settings(commonSettings)

--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
@@ -23,6 +23,7 @@ import cats.syntax.all._
 import feral.lambda.cloudformation.CloudFormationRequestType._
 import io.circe._
 import io.circe.syntax._
+import org.http4s.EntityEncoder
 import org.http4s.Method.PUT
 import org.http4s.circe._
 import org.http4s.client.Client
@@ -38,6 +39,12 @@ trait CloudFormationCustomResource[F[_], Input, Output] {
 }
 
 object CloudFormationCustomResource {
+  private implicit def jsonEncoder[F[_]]: EntityEncoder[F, Json] =
+    jsonEncoderWithPrinter(
+      Printer(
+        dropNullValues = true,
+        indent = ""
+      ))
 
   def apply[F[_]: MonadThrow, Input, Output: Encoder](
       client: Client[F],
@@ -62,7 +69,7 @@ object CloudFormationCustomResource {
 
   private def illegalRequestType[F[_]: ApplicativeThrow, A](other: String): F[A] =
     (new IllegalArgumentException(
-      s"unexpected CloudFormation request type `$other``"): Throwable).raiseError[F, A]
+      s"unexpected CloudFormation request type `$other`"): Throwable).raiseError[F, A]
 
   private def exceptionResponse[Input](req: CloudFormationCustomResourceRequest[Input])(
       ex: Throwable): CloudFormationCustomResourceResponse =

--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
@@ -40,11 +40,7 @@ trait CloudFormationCustomResource[F[_], Input, Output] {
 
 object CloudFormationCustomResource {
   private implicit def jsonEncoder[F[_]]: EntityEncoder[F, Json] =
-    jsonEncoderWithPrinter(
-      Printer(
-        dropNullValues = true,
-        indent = ""
-      ))
+    jsonEncoderWithPrinter(Printer.noSpaces.copy(dropNullValues = true))
 
   def apply[F[_]: MonadThrow, Input, Output: Encoder](
       client: Client[F],

--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
@@ -100,7 +100,9 @@ object CloudFormationCustomResource {
   private def stackTraceLines(throwable: Throwable): List[String] = {
     val writer = new StringWriter()
     throwable.printStackTrace(new PrintWriter(writer))
-    writer.toString.linesIterator.toList
+
+    // TODO figure out how to include more of the stack trace, up to a total response size of 4096 bytes
+    writer.toString.linesIterator.toList.take(1)
   }
 
 }

--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/package.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/package.scala
@@ -33,7 +33,20 @@ package object cloudformation {
 
 package cloudformation {
 
-  object PhysicalResourceId extends NewtypeWrapped[String] {
+  object PhysicalResourceId extends Newtype[String] {
+
+    /**
+     * Applies validation rules from
+     * https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-responses.html
+     */
+    def apply(s: String): Option[Type] =
+      Option.when(s.length <= 1024 && s.nonEmpty)(unsafeCoerce(s))
+
+    def unsafeApply(s: String): PhysicalResourceId = unsafeCoerce(s)
+
+    def unapply[A](a: A)(implicit ev: A =:= Type): Some[String] =
+      Some(value(ev(a)))
+
     implicit val PhysicalResourceIdDecoder: Decoder[PhysicalResourceId] = derive[Decoder]
     implicit val PhysicalResourceIdEncoder: Encoder[PhysicalResourceId] = derive[Encoder]
   }

--- a/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
+++ b/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
@@ -106,7 +106,7 @@ trait CloudFormationCustomResourceArbitraries {
       Gen.const(CreateRequest),
       Gen.const(UpdateRequest),
       Gen.const(DeleteRequest),
-      Gen.chooseNum(1, 100).flatMap(Gen.stringOfN(_, arbitrary[Char])).map(OtherRequestType)
+      Gen.chooseNum(1, 100).flatMap(Gen.stringOfN(_, arbitrary[Char])).map(OtherRequestType(_))
     )
   implicit val arbCloudFormationRequestType: Arbitrary[CloudFormationRequestType] = Arbitrary(
     genCloudFormationRequestType)

--- a/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
+++ b/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
@@ -189,10 +189,7 @@ trait CloudFormationCustomResourceArbitraries {
     for {
       e <- arbitrary[CloudFormationCustomResourceRequest[A]]
       c <- arbitrary[Context[F]]
-    } yield new LambdaEnv[F, CloudFormationCustomResourceRequest[A]] {
-      override def event: F[CloudFormationCustomResourceRequest[A]] = e.pure[F]
-      override def context: F[Context[F]] = c.pure[F]
-    }
+    } yield LambdaEnv.pure(e, c)
 
   implicit def arbLambdaEnv[F[_]: Applicative, A: Arbitrary]
       : Arbitrary[LambdaEnv[F, CloudFormationCustomResourceRequest[A]]] =

--- a/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/ResponseSerializationSuite.scala
+++ b/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/ResponseSerializationSuite.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feral.lambda
+package cloudformation
+
+import cats._
+import cats.effect._
+import cats.syntax.all._
+import com.eed3si9n.expecty.Expecty.expect
+import feral.lambda.cloudformation.CloudFormationRequestType._
+import io.circe.Json
+import io.circe.jawn.CirceSupportParser.facade
+import io.circe.literal._
+import io.circe.optics.JsonPath.root
+import io.circe.syntax._
+import munit._
+import org.http4s._
+import org.http4s.client.Client
+import org.http4s.dsl.io._
+import org.scalacheck.effect.PropF
+import org.typelevel.jawn.Parser
+
+import scala.concurrent.duration._
+
+class ResponseSerializationSuite
+    extends CatsEffectSuite
+    with ScalaCheckEffectSuite
+    with CloudFormationCustomResourceArbitraries {
+
+  private def captureRequestsAndRespondWithOk(
+      capture: Deferred[IO, (Request[IO], Json)]): HttpApp[IO] =
+    HttpApp { req =>
+      for {
+        body <- req.body.compile.to(Array).flatMap(Parser.parseFromByteArray(_).liftTo[IO])
+        _ <- capture.complete((req, body))
+        resp <- Ok()
+      } yield resp
+    }
+
+  /**
+   * Only compare the head of the stack trace array, because the rest of the stack trace is
+   * expected to vary too much
+   */
+  private val trimStackTrace = root.Data.StackTrace.arr.modify(_.take(1))
+
+  test("CloudFormationCustomResource should PUT the response to the given URI") {
+    PropF.forAllF {
+      implicit lambdaEnv: LambdaEnv[IO, CloudFormationCustomResourceRequest[String]] =>
+        for {
+          eventualRequest <- Deferred[IO, (Request[IO], Json)]
+          client = Client.fromHttpApp(captureRequestsAndRespondWithOk(eventualRequest))
+          _ <- CloudFormationCustomResource(client, new DoNothingCustomResource[IO])
+          (req, body) <- eventualRequest.get.timeout(2.seconds)
+          event <- lambdaEnv.event
+        } yield {
+          event.RequestType match {
+            case OtherRequestType(requestType) =>
+              val expectedReason = s"unexpected CloudFormation request type `$requestType`"
+              val expectedStackTraceHead =
+                s"java.lang.IllegalArgumentException: $expectedReason"
+              val expectedJson =
+                json"""{
+                       "Status": "FAILED",
+                       "Reason": $expectedReason,
+                       "PhysicalResourceId": ${event.PhysicalResourceId},
+                       "StackId": ${event.StackId},
+                       "RequestId": ${event.RequestId},
+                       "LogicalResourceId": ${event.LogicalResourceId},
+                       "Data": {
+                         "StackTrace": [
+                           $expectedStackTraceHead
+                         ]
+                       }
+                     }""".deepDropNullValues
+
+              val bodyWithTrimmedStackTrace = trimStackTrace(body)
+              expect(bodyWithTrimmedStackTrace eqv expectedJson)
+            case _ =>
+              val expectedJson = Json.obj(
+                "Status" -> "SUCCESS".asJson,
+                "PhysicalResourceId" -> event.ResourceProperties.asJson,
+                "StackId" -> event.StackId.asJson,
+                "RequestId" -> event.RequestId.asJson,
+                "LogicalResourceId" -> event.LogicalResourceId.asJson,
+                "Data" -> event.RequestType.asJson
+              )
+
+              // Use `eqv` here because we want to make sure nulls are dropped in the body we received
+              expect(body eqv expectedJson)
+          }
+
+          expect(req.method == PUT)
+          expect(req.uri == event.ResponseURL)
+        }
+    }
+  }
+}
+
+class DoNothingCustomResource[F[_]: Applicative]
+    extends CloudFormationCustomResource[F, String, CloudFormationRequestType] {
+  override def createResource(input: String): F[HandlerResponse[CloudFormationRequestType]] =
+    HandlerResponse(
+      PhysicalResourceId(input),
+      CreateRequest.some.widen[CloudFormationRequestType]).pure[F]
+  override def updateResource(input: String): F[HandlerResponse[CloudFormationRequestType]] =
+    HandlerResponse(
+      PhysicalResourceId(input),
+      UpdateRequest.some.widen[CloudFormationRequestType]).pure[F]
+  override def deleteResource(input: String): F[HandlerResponse[CloudFormationRequestType]] =
+    HandlerResponse(
+      PhysicalResourceId(input),
+      DeleteRequest.some.widen[CloudFormationRequestType]).pure[F]
+}

--- a/lambda/shared/src/main/scala/feral/lambda/LambdaEnv.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/LambdaEnv.scala
@@ -29,7 +29,7 @@ import cats.kernel.Monoid
 import cats.syntax.all._
 import cats.~>
 
-trait LambdaEnv[F[_], Event] { outer =>
+sealed trait LambdaEnv[F[_], Event] { outer =>
   def event: F[Event]
   def context: F[Context[F]]
 
@@ -45,6 +45,12 @@ object LambdaEnv {
 
   def event[F[_], Event](implicit env: LambdaEnv[F, Event]): F[Event] = env.event
   def context[F[_], Event](implicit env: LambdaEnv[F, Event]): F[Context[F]] = env.context
+
+  def pure[F[_]: Applicative, Event](e: Event, c: Context[F]): LambdaEnv[F, Event] =
+    new LambdaEnv[F, Event] {
+      override def event: F[Event] = e.pure[F]
+      override def context: F[Context[F]] = c.pure[F]
+    }
 
   implicit def kleisliLambdaEnv[F[_]: Functor, A, B](
       implicit env: LambdaEnv[F, A]): LambdaEnv[Kleisli[F, B, *], A] =

--- a/lambda/shared/src/main/scala/feral/lambda/LambdaEnv.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/LambdaEnv.scala
@@ -29,7 +29,7 @@ import cats.kernel.Monoid
 import cats.syntax.all._
 import cats.~>
 
-sealed trait LambdaEnv[F[_], Event] { outer =>
+trait LambdaEnv[F[_], Event] { outer =>
   def event: F[Event]
   def context: F[Context[F]]
 


### PR DESCRIPTION
This drops null values from the responses, and minimizes the stack traces included in failure responses to help make sure the responses stay under 4KB.