### PR TITLE
tweak CloudFormationCustomResourceResponse decoder

### DIFF
--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/CloudFormationCustomResource.scala
@@ -35,7 +35,7 @@ trait CloudFormationCustomResource[F[_], Input, Output] {
 }
 
 object CloudFormationCustomResource {
-  private implicit def jsonEncoder[F[_]]: EntityEncoder[F, Json] =
+  private[cloudformation] implicit def jsonEncoder[F[_]]: EntityEncoder[F, Json] =
     jsonEncoderWithPrinter(Printer.noSpaces.copy(dropNullValues = true))
 
   def apply[F[_]: MonadThrow, Input, Output: Encoder](
@@ -63,7 +63,7 @@ object CloudFormationCustomResource {
     (new IllegalArgumentException(
       s"unexpected CloudFormation request type `$other`"): Throwable).raiseError[F, A]
 
-  private def exceptionResponse[Input](req: CloudFormationCustomResourceRequest[Input])(
+  private[cloudformation] def exceptionResponse(req: CloudFormationCustomResourceRequest[_])(
       ex: Throwable): CloudFormationCustomResourceResponse =
     CloudFormationCustomResourceResponse(
       Status = RequestResponseStatus.Failed,
@@ -76,8 +76,8 @@ object CloudFormationCustomResource {
         "StackTrace" -> Json.arr(stackTraceLines(ex).map(Json.fromString): _*)).asJson
     )
 
-  private def successResponse[Input, Output: Encoder](
-      req: CloudFormationCustomResourceRequest[Input])(
+  private[cloudformation] def successResponse[Output: Encoder](
+      req: CloudFormationCustomResourceRequest[_])(
       res: HandlerResponse[Output]): CloudFormationCustomResourceResponse =
     CloudFormationCustomResourceResponse(
       Status = RequestResponseStatus.Success,

--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/package.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/package.scala
@@ -171,15 +171,24 @@ package cloudformation {
   object CloudFormationCustomResourceResponse {
     implicit val CloudFormationCustomResourceResponseDecoder
         : Decoder[CloudFormationCustomResourceResponse] =
-      Decoder.forProduct7(
-        "Status",
-        "Reason",
-        "PhysicalResourceId",
-        "StackId",
-        "RequestId",
-        "LogicalResourceId",
-        "Data"
-      )(CloudFormationCustomResourceResponse.apply)
+      Decoder
+        .forProduct7(
+          "Status",
+          "Reason",
+          "PhysicalResourceId",
+          "StackId",
+          "RequestId",
+          "LogicalResourceId",
+          "Data"
+        )(CloudFormationCustomResourceResponse.apply)
+        .prepare {
+          _.withFocus {
+            _.mapObject { obj =>
+              if (obj.contains("Data")) obj
+              else obj.add("Data", Json.Null)
+            }
+          }
+        }
 
     implicit val CloudFormationCustomResourceResponseEncoder
         : Encoder[CloudFormationCustomResourceResponse] =


### PR DESCRIPTION
Right now it doesn't work with the JSON emitted by Feral if the `Data` element is empty, because `null`s are pruned by the JSON printer. This doesn't matter in normal use, but it means the decoder can't be used in some testing scenarios.