### PR TITLE
Changed ApiGatewayProxyEventV2 cookies field to optional

### DIFF
--- a/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
+++ b/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
@@ -40,9 +40,7 @@ object ApiGatewayProxyHandler {
       event <- LambdaEnv.event
       method <- Method.fromString(event.requestContext.http.method).liftTo[F]
       uri <- Uri.fromString(event.rawPath + "?" + event.rawQueryString).liftTo[F]
-      cookies = Some(event.cookies)
-        .filter(_.nonEmpty)
-        .map(Cookie.name.toString -> _.mkString("; "))
+      cookies = event.cookies.filter(_.nonEmpty).map(Cookie.name.toString -> _.mkString("; "))
       headers = Headers(cookies.toList ::: event.headers.toList)
       readBody =
         if (event.isBase64Encoded)
@@ -80,9 +78,7 @@ object ApiGatewayProxyHandler {
       event: ApiGatewayProxyEventV2): F[Request[F]] = for {
     method <- Method.fromString(event.requestContext.http.method).liftTo[F]
     uri <- Uri.fromString(event.rawPath + "?" + event.rawQueryString).liftTo[F]
-    cookies = Some(event.cookies)
-      .filter(_.nonEmpty)
-      .map(Cookie.name.toString -> _.mkString("; "))
+    cookies = event.cookies.filter(_.nonEmpty).map(Cookie.name.toString -> _.mkString("; "))
     headers = Headers(cookies.toList ::: event.headers.toList)
     readBody =
       if (event.isBase64Encoded)

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
@@ -34,7 +34,7 @@ object RequestContext {
 final case class ApiGatewayProxyEventV2(
     rawPath: String,
     rawQueryString: String,
-    cookies: List[String],
+    cookies: Option[List[String]],
     headers: Map[String, String],
     requestContext: RequestContext,
     body: Option[String],


### PR DESCRIPTION
I was trying out the api-gateway proxy integration and found it was failing due to the `cookies` field in the request not being present by default. I couldn't find anything official but [this Typescript model](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d7d9c1d76dead09380e702d858b40432a29d8a48/types/aws-lambda/trigger/api-gateway-proxy.d.ts#L174) seems to agree. Let me know if you prefer I add some additional tests.

Thanks for the project! I have had really nice results testing it out so far.