### PR TITLE
Add SNSEvent, update to circe-* 0.15.0-M1, use jawn on all platforms

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ val Scala3 = "3.1.1"
 ThisBuild / crossScalaVersions := Seq(Scala212, Scala3, Scala213)
 
 val catsEffectVersion = "3.3.11"
-val circeVersion = "0.14.1"
+val circeVersion = "0.15.0-M1"
 val fs2Version = "3.2.7"
 val http4sVersion = "0.23.11"
 val natchezVersion = "0.1.6"
@@ -97,7 +97,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "org.tpolecat" %%% "natchez-core" % natchezVersion,
       "io.circe" %%% "circe-scodec" % circeVersion,
-      "io.circe" %%% "circe-parser" % circeVersion,
+      "io.circe" %%% "circe-jawn" % circeVersion,
       "org.scodec" %%% "scodec-bits" % "1.1.30",
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
       "org.typelevel" %%% "munit-cats-effect-3" % munitCEVersion % Test
@@ -106,8 +106,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
       if (tlIsScala3.value) Nil
       else
         Seq(
-          "io.circe" %%% "circe-literal" % circeVersion % Test,
-          "io.circe" %% "circe-jawn" % circeVersion % Test // %% b/c used for literal macro at compile-time only
+          "io.circe" %%% "circe-literal" % circeVersion % Test
         )
     }
   )

--- a/build.sbt
+++ b/build.sbt
@@ -97,6 +97,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "org.tpolecat" %%% "natchez-core" % natchezVersion,
       "io.circe" %%% "circe-scodec" % circeVersion,
+      "io.circe" %%% "circe-parser" % circeVersion,
       "org.scodec" %%% "scodec-bits" % "1.1.30",
       "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
       "org.typelevel" %%% "munit-cats-effect-3" % munitCEVersion % Test
@@ -121,7 +122,6 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.1",
       "co.fs2" %%% "fs2-io" % fs2Version,
-      "io.circe" %%% "circe-jawn" % circeVersion,
       "io.circe" %%% "circe-fs2" % "0.14.0"
     )
   )

--- a/lambda/jvm/src/main/scala/feral/lambda/ContextPlatform.scala
+++ b/lambda/jvm/src/main/scala/feral/lambda/ContextPlatform.scala
@@ -19,7 +19,7 @@ package feral.lambda
 import cats.effect.Sync
 import com.amazonaws.services.lambda.runtime
 import io.circe.JsonObject
-import io.circe.parser.parse
+import io.circe.jawn.parse
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._

--- a/lambda/jvm/src/main/scala/feral/lambda/ContextPlatform.scala
+++ b/lambda/jvm/src/main/scala/feral/lambda/ContextPlatform.scala
@@ -19,7 +19,7 @@ package feral.lambda
 import cats.effect.Sync
 import com.amazonaws.services.lambda.runtime
 import io.circe.JsonObject
-import io.circe.jawn
+import io.circe.parser.parse
 
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
@@ -56,7 +56,7 @@ private[lambda] trait ContextCompanionPlatform {
           ),
           JsonObject.fromIterable(clientContext.getCustom().asScala.view.flatMap {
             case (k, v) =>
-              jawn.parse(v).toOption.map(k -> _)
+              parse(v).toOption.map(k -> _)
           })
         )
       },

--- a/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
@@ -19,7 +19,7 @@ package events
 
 import cats.syntax.all._
 import io.circe.Decoder
-import io.circe.parser.decode
+import io.circe.jawn.decode
 import io.circe.scodec._
 import scodec.bits.ByteVector
 

--- a/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.lambda
 package events
 
@@ -9,89 +25,6 @@ import scodec.bits.ByteVector
 
 import java.time.Instant
 import java.util.UUID
-import scala.util.Try
-
-/*
-{
-  "Records": [
-    {
-      "EventVersion": "1.0",
-      "EventSubscriptionArn": "arn:aws:sns:TEST",
-      "EventSource": "aws:sns",
-      "Sns": {
-        "Signature": "TEST",
-        "MessageId": "9f0cfa95-e344-4f93-89ab-5e979503ed1f",
-        "Type": "Notification",
-        "TopicArn": "arn:aws:sns:TEST",
-        "MessageAttributes": {
-          "string": {
-            "Type": "String",
-            "Value": "Testing"
-          },
-          "binary": {
-            "Type": "Binary",
-            "Value": "Testing"
-          },
-          "number": {
-            "Type": "Number",
-            "Value": 1e6
-          },
-          "numberString": {
-            "Type": "Number",
-            "Value": "5"
-          },
-          "array": {
-            "Type": "String.Array",
-            "Value": "[1, \"two\", true, false]"
-          },
-          "unsupported": {
-            "Type": "FancyNewType",
-            "Value": "SpecialValueHere"
-          }
-        },
-        "SignatureVersion": "1",
-        "Timestamp": "2022-04-06T01:02:03.456Z",
-        "SigningCertUrl": "TEST",
-        "Message": "Testing Message",
-        "UnsubscribeUrl": "TEST",
-        "Subject": "Test Message"
-      }
-    }
-  ]
-}
-
-==>
-
-SnsEvent(
-  List(
-    SnsRecord(
-      "1.0",
-      "arn:aws:sns:TEST",
-      "aws:sns",
-      SnsMessage(
-        "TEST",
-        9f0cfa95-e344-4f93-89ab-5e979503ed1f,
-        "Notification",
-        "arn:aws:sns:TEST",
-        Map(
-          "number" -> Number(1E+6),
-          "binary" -> Binary(ByteVector(5 bytes, 0x4deb2d8a78)),
-          "string" -> String("Testing"),
-          "numberString" -> Number(5),
-          "array" -> StringArray(List(Number(1), String("two"), Boolean(true), Boolean(false))),
-          "unsupported" -> Unknown("FancyNewType", Some("SpecialValueHere"))
-        ),
-        "1",
-        2022-04-06T01:02:03.456Z,
-        "TEST",
-        "Testing Message",
-        "TEST",
-        "Test Message"
-      )
-    )
-  )
-)
- */
 
 final case class SnsEvent(
     records: List[SnsEventRecord]
@@ -133,11 +66,8 @@ final case class SnsMessage(
 )
 
 object SnsMessage {
-  implicit val instantDecoder: Decoder[Instant] = Decoder.decodeString.emapTry { str =>
-    Try {
-      Instant.parse(str)
-    }
-  }
+  implicit val instantDecoder: Decoder[Instant] = Decoder.decodeInstant
+
   implicit val decoder: Decoder[SnsMessage] = Decoder.forProduct11(
     "Signature",
     "MessageId",

--- a/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
@@ -1,0 +1,223 @@
+package feral.lambda
+package events
+
+import cats.syntax.all._
+import io.circe.Decoder
+import io.circe.parser.decode
+import io.circe.scodec._
+import scodec.bits.ByteVector
+
+import java.time.Instant
+import java.util.UUID
+import scala.util.Try
+
+/*
+{
+  "Records": [
+    {
+      "EventVersion": "1.0",
+      "EventSubscriptionArn": "arn:aws:sns:TEST",
+      "EventSource": "aws:sns",
+      "Sns": {
+        "Signature": "TEST",
+        "MessageId": "9f0cfa95-e344-4f93-89ab-5e979503ed1f",
+        "Type": "Notification",
+        "TopicArn": "arn:aws:sns:TEST",
+        "MessageAttributes": {
+          "string": {
+            "Type": "String",
+            "Value": "Testing"
+          },
+          "binary": {
+            "Type": "Binary",
+            "Value": "Testing"
+          },
+          "number": {
+            "Type": "Number",
+            "Value": 1e6
+          },
+          "numberString": {
+            "Type": "Number",
+            "Value": "5"
+          },
+          "array": {
+            "Type": "String.Array",
+            "Value": "[1, \"two\", true, false]"
+          },
+          "unsupported": {
+            "Type": "FancyNewType",
+            "Value": "SpecialValueHere"
+          }
+        },
+        "SignatureVersion": "1",
+        "Timestamp": "2022-04-06T01:02:03.456Z",
+        "SigningCertUrl": "TEST",
+        "Message": "Testing Message",
+        "UnsubscribeUrl": "TEST",
+        "Subject": "Test Message"
+      }
+    }
+  ]
+}
+
+==>
+
+SnsEvent(
+  List(
+    SnsRecord(
+      "1.0",
+      "arn:aws:sns:TEST",
+      "aws:sns",
+      SnsMessage(
+        "TEST",
+        9f0cfa95-e344-4f93-89ab-5e979503ed1f,
+        "Notification",
+        "arn:aws:sns:TEST",
+        Map(
+          "number" -> Number(1E+6),
+          "binary" -> Binary(ByteVector(5 bytes, 0x4deb2d8a78)),
+          "string" -> String("Testing"),
+          "numberString" -> Number(5),
+          "array" -> StringArray(List(Number(1), String("two"), Boolean(true), Boolean(false))),
+          "unsupported" -> Unknown("FancyNewType", Some("SpecialValueHere"))
+        ),
+        "1",
+        2022-04-06T01:02:03.456Z,
+        "TEST",
+        "Testing Message",
+        "TEST",
+        "Test Message"
+      )
+    )
+  )
+)
+ */
+
+final case class SnsEvent(
+    records: List[SnsEventRecord]
+)
+
+object SnsEvent {
+  implicit val decoder: Decoder[SnsEvent] =
+    Decoder.forProduct1("Records")(SnsEvent.apply)
+}
+
+final case class SnsEventRecord(
+    eventVersion: String,
+    eventSubscriptionArn: String,
+    eventSource: String,
+    sns: SnsMessage
+)
+
+object SnsEventRecord {
+  implicit val decoder: Decoder[SnsEventRecord] = Decoder.forProduct4(
+    "EventVersion",
+    "EventSubscriptionArn",
+    "EventSource",
+    "Sns"
+  )(SnsEventRecord.apply)
+}
+
+final case class SnsMessage(
+    signature: String,
+    messageId: UUID,
+    `type`: String,
+    topicArn: String,
+    messageAttributes: Map[String, SnsMessageAttribute],
+    signatureVersion: String,
+    timestamp: Instant,
+    signingCertUrl: String,
+    message: String,
+    unsubscribeUrl: String,
+    subject: String
+)
+
+object SnsMessage {
+  implicit val instantDecoder: Decoder[Instant] = Decoder.decodeString.emapTry { str =>
+    Try {
+      Instant.parse(str)
+    }
+  }
+  implicit val decoder: Decoder[SnsMessage] = Decoder.forProduct11(
+    "Signature",
+    "MessageId",
+    "Type",
+    "TopicArn",
+    "MessageAttributes",
+    "SignatureVersion",
+    "Timestamp",
+    "SigningCertUrl",
+    "Message",
+    "UnsubscribeUrl",
+    "Subject"
+  )(SnsMessage.apply)
+}
+
+sealed abstract class SnsMessageAttribute
+
+object SnsMessageAttribute {
+  final case class String(value: Predef.String) extends SnsMessageAttribute
+  final case class Binary(value: ByteVector) extends SnsMessageAttribute
+  final case class Number(value: BigDecimal) extends SnsMessageAttribute
+  final case class StringArray(value: List[SnsMessageAttributeArrayMember])
+      extends SnsMessageAttribute
+  final case class Unknown(
+      `type`: Predef.String,
+      value: Option[Predef.String]
+  ) extends SnsMessageAttribute
+
+  implicit val decoder: Decoder[SnsMessageAttribute] = {
+    val getString: Decoder[Predef.String] = Decoder.instance(_.get[Predef.String]("Value"))
+    val getByteVector: Decoder[ByteVector] = Decoder.instance(_.get[ByteVector]("Value"))
+    val getNumber: Decoder[BigDecimal] = Decoder.instance(_.get[BigDecimal]("Value"))
+
+    /*
+    See https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html
+
+    In particular, for both Number and String.Array:
+
+    > This data type isn't supported for AWS Lambda subscriptions. If you specify this data type for Lambda endpoints,
+    > it's passed as the String data type in the JSON payload that Amazon SNS delivers to Lambda."
+
+    Circe is smart enough to handle this for BigDecimal, but no such luck for this particular mess.
+     */
+
+    val getStringArray: Decoder[List[SnsMessageAttributeArrayMember]] =
+      getString.emapTry(decode[List[SnsMessageAttributeArrayMember]](_).toTry)
+
+    Decoder.instance(_.get[Predef.String]("Type")).flatMap {
+      case "String" => getString.map(SnsMessageAttribute.String.apply)
+      case "Binary" => getByteVector.map(SnsMessageAttribute.Binary.apply)
+      case "Number" => getNumber.map(SnsMessageAttribute.Number.apply)
+      case "String.Array" => getStringArray.map(SnsMessageAttribute.StringArray.apply)
+      case someType =>
+        Decoder.instance(i =>
+          i.get[Option[Predef.String]]("Value").map(SnsMessageAttribute.Unknown(someType, _)))
+    }
+  }
+}
+
+sealed abstract class SnsMessageAttributeArrayMember
+
+object SnsMessageAttributeArrayMember {
+  final case class String(value: Predef.String) extends SnsMessageAttributeArrayMember
+  final case class Number(value: BigDecimal) extends SnsMessageAttributeArrayMember
+  final case class Boolean(value: scala.Boolean) extends SnsMessageAttributeArrayMember
+
+  implicit val decoder: Decoder[SnsMessageAttributeArrayMember] = {
+    val bool: Decoder[SnsMessageAttributeArrayMember.Boolean] =
+      Decoder.decodeBoolean.map(SnsMessageAttributeArrayMember.Boolean.apply)
+
+    val number: Decoder[SnsMessageAttributeArrayMember.Number] =
+      Decoder.decodeBigDecimal.map(SnsMessageAttributeArrayMember.Number.apply)
+
+    val string: Decoder[SnsMessageAttributeArrayMember.String] =
+      Decoder.decodeString.map(SnsMessageAttributeArrayMember.String.apply)
+
+    List[Decoder[SnsMessageAttributeArrayMember]](
+      bool.widen,
+      number.widen,
+      string.widen
+    ).reduce(_ or _)
+  }
+}

--- a/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
@@ -66,7 +66,7 @@ final case class SnsMessage(
 )
 
 object SnsMessage {
-  implicit val instantDecoder: Decoder[Instant] = Decoder.decodeInstant
+  private[this] implicit val instantDecoder: Decoder[Instant] = Decoder.decodeInstant
 
   implicit val decoder: Decoder[SnsMessage] = Decoder.forProduct11(
     "Signature",

--- a/lambda/shared/src/test/scala-2/feral/lambda/events/SnsEventSuite.scala
+++ b/lambda/shared/src/test/scala-2/feral/lambda/events/SnsEventSuite.scala
@@ -1,0 +1,65 @@
+package feral.lambda.events
+
+import io.circe.Json
+import io.circe.literal._
+import munit.FunSuite
+
+class SnsEventSuite extends FunSuite {
+  import SnsEventSuite._
+
+  test("decoder") {
+    event.as[SnsEvent].toTry.get
+  }
+}
+
+object SnsEventSuite {
+  val event: Json = json"""
+    {
+      "Records": [
+        {
+          "EventVersion": "1.0",
+          "EventSubscriptionArn": "arn:aws:sns:TEST",
+          "EventSource": "aws:sns",
+          "Sns": {
+            "Signature": "TEST",
+            "MessageId": "9f0cfa95-e344-4f93-89ab-5e979503ed1f",
+            "Type": "Notification",
+            "TopicArn": "arn:aws:sns:TEST",
+            "MessageAttributes": {
+              "string": {
+                "Type": "String",
+                "Value": "Testing"
+              },
+              "binary": {
+                "Type": "Binary",
+                "Value": "Testing"
+              },
+              "number": {
+                "Type": "Number",
+                "Value": 1e6
+              },
+              "numberString": {
+                "Type": "Number",
+                "Value": "5"
+              },
+              "array": {
+                "Type": "String.Array",
+                "Value": "[1, \"two\", true, false]"
+              },
+              "unsupported": {
+                "Type": "FancyNewType",
+                "Value": "SpecialValueHere"
+              }
+            },
+            "SignatureVersion": "1",
+            "Timestamp": "2022-04-06T01:02:03.456Z",
+            "SigningCertUrl": "TEST",
+            "Message": "Testing Message",
+            "UnsubscribeUrl": "TEST",
+            "Subject": "Test Message"
+          }
+        }
+      ]
+    }
+  """
+}

--- a/lambda/shared/src/test/scala-2/feral/lambda/events/SnsEventSuite.scala
+++ b/lambda/shared/src/test/scala-2/feral/lambda/events/SnsEventSuite.scala
@@ -28,7 +28,7 @@ class SnsEventSuite extends FunSuite {
   import SnsEventSuite._
 
   test("decoder") {
-    assert(clue(event.as[SnsEvent].toTry.get) == clue(decoded))
+    assertEquals(event.as[SnsEvent].toTry.get, decoded)
   }
 }
 

--- a/lambda/shared/src/test/scala-2/feral/lambda/events/SnsEventSuite.scala
+++ b/lambda/shared/src/test/scala-2/feral/lambda/events/SnsEventSuite.scala
@@ -1,18 +1,75 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.lambda.events
 
 import io.circe.Json
 import io.circe.literal._
 import munit.FunSuite
+import scodec.bits.ByteVector
+
+import java.time.Instant
+import java.util.UUID
 
 class SnsEventSuite extends FunSuite {
   import SnsEventSuite._
 
   test("decoder") {
-    event.as[SnsEvent].toTry.get
+    assert(clue(event.as[SnsEvent].toTry.get) == clue(decoded))
   }
 }
 
 object SnsEventSuite {
+  val decoded: SnsEvent =
+    SnsEvent(
+      List(
+        SnsEventRecord(
+          "1.0",
+          "arn:aws:sns:TEST",
+          "aws:sns",
+          SnsMessage(
+            "TEST",
+            UUID.fromString("9f0cfa95-e344-4f93-89ab-5e979503ed1f"),
+            "Notification",
+            "arn:aws:sns:TEST",
+            Map(
+              "number" -> SnsMessageAttribute.Number(1e+6),
+              "binary" -> SnsMessageAttribute.Binary(ByteVector.fromBase64("VGVzdGluZwo=").get),
+              "string" -> SnsMessageAttribute.String("Testing"),
+              "numberString" -> SnsMessageAttribute.Number(5),
+              "array" -> SnsMessageAttribute.StringArray(List(
+                SnsMessageAttributeArrayMember.Number(1),
+                SnsMessageAttributeArrayMember.String("two"),
+                SnsMessageAttributeArrayMember.Boolean(true),
+                SnsMessageAttributeArrayMember.Boolean(false)
+              )),
+              "unsupported" -> SnsMessageAttribute
+                .Unknown("FancyNewType", Some("SpecialValueHere"))
+            ),
+            "1",
+            Instant.parse("2022-04-06T01:02:03.456Z"),
+            "TEST",
+            "Testing Message",
+            "TEST",
+            "Test Message"
+          )
+        )
+      )
+    )
+
   val event: Json = json"""
     {
       "Records": [
@@ -32,7 +89,7 @@ object SnsEventSuite {
               },
               "binary": {
                 "Type": "Binary",
-                "Value": "Testing"
+                "Value": "VGVzdGluZwo="
               },
               "number": {
                 "Type": "Number",


### PR DESCRIPTION
I'd like to use Feral for a project, but wouldn't you know it! The very first event type I need to respond to isn't set up, yet.

I had to bring in `circe-parser` to be able to deal with `String.Array` properly, which as I understand it obviates the need for `circe-jawn` since `circe-parser` is Jawn on the JVM and `JSON.parse` on ScalaJS. Since the dependency was only actually used once on the JVM side and I needed the more general one, anyway, it seemed reasonable to make that change. Happy to find a better way if that'd be preferred, though.

For SnsMessageAttributes, we're lenient with acceptable attributes but strict in the interpretation of documented types. E.g., `String.Array` will not accept any values that can't be parsed as `Boolean`, `BigDecimal`, or `String`, in that order.

This is a strictly stronger contract than what's enforced by, say, [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/566941a83b5a1b3bed3ec9c8cede12fd3ebdb513/types/aws-lambda/trigger/sns.d.ts) or [aws-lambda-go](https://github.com/aws/aws-lambda-go/blob/bc1ec47cb1670c0d5eaca47c10d89789d8507c3d/events/sns.go), but it aligns with [the documented properties](https://docs.aws.amazon.com/sns/latest/dg/sns-message-attributes.html). Happy to loosen things up if that'd be preferred, but it was natural enough once I got over the `String.Array` hump.