### PR TITLE
Establish `series/1.x` against http4s 1.0.0 milestones

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,7 +59,7 @@ ThisBuild / crossScalaVersions := Seq(Scala212, Scala3, Scala213)
 val catsEffectVersion = "3.3.12"
 val circeVersion = "0.14.2"
 val fs2Version = "3.2.7"
-val http4sVersion = "0.23.12"
+val http4sVersion = "1.0.0-M33"
 val natchezVersion = "0.1.6"
 val munitVersion = "0.7.29"
 val munitCEVersion = "1.0.7"
@@ -181,7 +181,6 @@ lazy val examples = crossProject(JSPlatform, JVMPlatform)
       "org.http4s" %%% "http4s-dsl" % http4sVersion,
       "org.http4s" %%% "http4s-ember-client" % http4sVersion,
       "org.tpolecat" %%% "natchez-xray" % natchezVersion,
-      "org.tpolecat" %%% "natchez-http4s" % "0.3.2",
       "org.tpolecat" %%% "skunk-core" % "0.3.1"
     )
   )

--- a/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
+++ b/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
@@ -27,6 +27,7 @@ import org.http4s.Charset
 import org.http4s.Entity
 import org.http4s.Headers
 import org.http4s.HttpRoutes
+import org.http4s.MalformedMessageBodyFailure
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Response
@@ -34,7 +35,6 @@ import org.http4s.Uri
 import org.http4s.headers.Cookie
 import org.http4s.headers.`Set-Cookie`
 import scodec.bits.ByteVector
-import org.http4s.MalformedMessageBodyFailure
 
 object ApiGatewayProxyHandler {
 

--- a/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
+++ b/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
@@ -45,10 +45,19 @@ object ApiGatewayProxyHandler {
       request <- decodeEvent(event)
       response <- routes(request).getOrElse(Response.notFound)
       isBase64Encoded = !response.charset.contains(Charset.`UTF-8`)
-      responseBody <- (if (isBase64Encoded)
-                         response.body.through(fs2.text.base64.encode)
-                       else
-                         response.body.through(fs2.text.utf8.decode)).compile.foldMonoid
+      responseBody <- response.entity match {
+        case Entity.Empty => "".pure
+        case Entity.Strict(chunk) => // TODO
+          if (isBase64Encoded) chunk.toByteVector.toBase64.pure
+          else chunk.toByteVector.decodeUtf8.liftTo
+        case Entity.Default(body, _) =>
+          body
+            .through(
+              if (isBase64Encoded) fs2.text.base64.encode else fs2.text.utf8.decode
+            )
+            .compile
+            .string
+      }
     } yield {
       val headers = response.headers.headers.groupMap(_.name)(_.value)
       Some(


### PR DESCRIPTION
As if we're not already neck-deep in our own milestones :)

Why start `series/1.x` instead of `series/0.2` for these milestones? Because we may need to bump to 0.2.0 before http4s 1.0.0 finalizes, and it would be awkward to rollback to 0.23. Meanwhile, we cannot 1.0.0 ourselves until all of our dependencies 1.0.0 including http4s, so it is sufficiently in the future.

We should really avoid doing any feature development on this branch. At the moment it exists solely to track http4s 1.0.0 milestones.

Overall changes:
1. Bump to http4s 1.0.0-M33.
2. Fixes/optimizations in the lambda-http4s integration module, to account for the new http4s entity model.
3. Drop natchez-http4s from our examples, because it is not tracking the http4s 1.0.0 milestones.