### PR TITLE
add PhysicalResourceId to CloudFormation Custom Resource interface

### DIFF
--- a/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/package.scala
+++ b/lambda-cloudformation-custom-resource/src/main/scala/feral/lambda/cloudformation/package.scala
@@ -72,7 +72,9 @@ package cloudformation {
     case object CreateRequest extends CloudFormationRequestType
     case object UpdateRequest extends CloudFormationRequestType
     case object DeleteRequest extends CloudFormationRequestType
-    final case class OtherRequestType(requestType: String) extends CloudFormationRequestType
+    final case class OtherRequestType(requestType: String) extends CloudFormationRequestType {
+      override def toString: String = requestType
+    }
 
     implicit val encoder: Encoder[CloudFormationRequestType] = {
       case CreateRequest => "Create".asJson

--- a/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
+++ b/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
@@ -165,7 +165,7 @@ trait CloudFormationCustomResourceArbitraries {
       requestId <- arbitrary[RequestId]
       resourceType <- arbitrary[ResourceType]
       logicalResourceId <- arbitrary[LogicalResourceId]
-      physicalResourceId <- arbitrary[Option[PhysicalResourceId]]
+      physicalResourceId <- arbitrary[PhysicalResourceId]
       resourceProperties <- arbitrary[A]
       oldResourceProperties <- arbitrary[Option[JsonObject]]
     } yield CloudFormationCustomResourceRequest(
@@ -175,7 +175,7 @@ trait CloudFormationCustomResourceArbitraries {
       requestId,
       resourceType,
       logicalResourceId,
-      physicalResourceId,
+      if (requestType == CreateRequest) None else physicalResourceId.some,
       resourceProperties,
       oldResourceProperties
     )

--- a/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/ResponseSerializationSuite.scala
+++ b/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/ResponseSerializationSuite.scala
@@ -83,11 +83,20 @@ class ResponseSerializationSuite
                   }
                 )
                 .deepDropNullValues
-            case _ =>
+            case CreateRequest =>
               Json.obj(
                 "Status" -> "SUCCESS".asJson,
                 "PhysicalResourceId" -> convertInputToFakePhysicalResourceId(
                   event.ResourceProperties).asJson,
+                "StackId" -> event.StackId.asJson,
+                "RequestId" -> event.RequestId.asJson,
+                "LogicalResourceId" -> event.LogicalResourceId.asJson,
+                "Data" -> event.RequestType.asJson
+              )
+            case UpdateRequest | DeleteRequest =>
+              Json.obj(
+                "Status" -> "SUCCESS".asJson,
+                "PhysicalResourceId" -> event.PhysicalResourceId.get.asJson,
                 "StackId" -> event.StackId.asJson,
                 "RequestId" -> event.RequestId.asJson,
                 "LogicalResourceId" -> event.LogicalResourceId.asJson,
@@ -142,14 +151,16 @@ object ResponseSerializationSuite {
         convertInputToFakePhysicalResourceId(input),
         CreateRequest.some.widen[CloudFormationRequestType]).pure[F]
 
-    override def updateResource(input: String): F[HandlerResponse[CloudFormationRequestType]] =
-      HandlerResponse(
-        convertInputToFakePhysicalResourceId(input),
-        UpdateRequest.some.widen[CloudFormationRequestType]).pure[F]
+    override def updateResource(
+        input: String,
+        physicalResourceId: PhysicalResourceId): F[HandlerResponse[CloudFormationRequestType]] =
+      HandlerResponse(physicalResourceId, UpdateRequest.some.widen[CloudFormationRequestType])
+        .pure[F]
 
-    override def deleteResource(input: String): F[HandlerResponse[CloudFormationRequestType]] =
-      HandlerResponse(
-        convertInputToFakePhysicalResourceId(input),
-        DeleteRequest.some.widen[CloudFormationRequestType]).pure[F]
+    override def deleteResource(
+        input: String,
+        physicalResourceId: PhysicalResourceId): F[HandlerResponse[CloudFormationRequestType]] =
+      HandlerResponse(physicalResourceId, DeleteRequest.some.widen[CloudFormationRequestType])
+        .pure[F]
   }
 }


### PR DESCRIPTION
`PhysicalResourceId` is "always sent with Update and Delete requests; never sent with Create" ([according to AWS docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/crpg-ref-requests.html#crpg-ref-request-physicalresourceid)) and is commonly required to actually perform the work needed to do an update or delete of the resource. This PR encodes that contract and makes life a bit easier for developers implementing update/delete, since they won't have to deal with the optionality of the value in the event encoding.

Obviously this is a breaking change to the interface, thus my comment on https://github.com/typelevel/feral/issues/209#issuecomment-1133172755.