### PR TITLE
Use `sealed abstract case class`es to reduce bincompat surface

### DIFF
--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
@@ -23,6 +23,7 @@ import natchez.Kernel
 sealed abstract case class Http private (method: String)
 object Http {
   private[lambda] def apply(method: String): Http = new Http(method) {}
+  private[lambda] def unapply(http: Http): Nothing = ???
 
   implicit val decoder: Decoder[Http] = Decoder.forProduct1("method")(Http.apply)
 }
@@ -30,6 +31,7 @@ object Http {
 sealed abstract case class RequestContext private (http: Http)
 object RequestContext {
   private[lambda] def apply(http: Http): RequestContext = new RequestContext(http) {}
+  private[lambda] def unapply(requestContext: RequestContext): Nothing = ???
 
   implicit val decoder: Decoder[RequestContext] =
     Decoder.forProduct1("http")(RequestContext.apply)
@@ -64,6 +66,8 @@ object ApiGatewayProxyEventV2 {
       body,
       isBase64Encoded
     ) {}
+
+  private[lambda] def unapply(event: ApiGatewayProxyEventV2): Nothing = ???
 
   implicit def decoder: Decoder[ApiGatewayProxyEventV2] = Decoder.forProduct7(
     "rawPath",

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
@@ -20,18 +20,22 @@ package events
 import io.circe.Decoder
 import natchez.Kernel
 
-final case class Http(method: String)
+sealed abstract case class Http private (method: String)
 object Http {
+  private[lambda] def apply(method: String): Http = new Http(method) {}
+
   implicit val decoder: Decoder[Http] = Decoder.forProduct1("method")(Http.apply)
 }
-final case class RequestContext(http: Http)
 
+sealed abstract case class RequestContext private (http: Http)
 object RequestContext {
+  private[lambda] def apply(http: Http): RequestContext = new RequestContext(http) {}
+
   implicit val decoder: Decoder[RequestContext] =
     Decoder.forProduct1("http")(RequestContext.apply)
 }
 
-final case class ApiGatewayProxyEventV2(
+sealed abstract case class ApiGatewayProxyEventV2 private (
     rawPath: String,
     rawQueryString: String,
     cookies: Option[List[String]],
@@ -42,6 +46,25 @@ final case class ApiGatewayProxyEventV2(
 )
 
 object ApiGatewayProxyEventV2 {
+  private[lambda] def apply(
+      rawPath: String,
+      rawQueryString: String,
+      cookies: Option[List[String]],
+      headers: Map[String, String],
+      requestContext: RequestContext,
+      body: Option[String],
+      isBase64Encoded: Boolean
+  ): ApiGatewayProxyEventV2 =
+    new ApiGatewayProxyEventV2(
+      rawPath,
+      rawQueryString,
+      cookies,
+      headers,
+      requestContext,
+      body,
+      isBase64Encoded
+    ) {}
+
   implicit def decoder: Decoder[ApiGatewayProxyEventV2] = Decoder.forProduct7(
     "rawPath",
     "rawQueryString",

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResultV2.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResultV2.scala
@@ -42,6 +42,8 @@ object ApiGatewayProxyStructuredResultV2 {
       cookies
     ) {}
 
+  private[lambda] def unapply(result: ApiGatewayProxyStructuredResultV2): Nothing = ???
+
   implicit def encoder: Encoder[ApiGatewayProxyStructuredResultV2] = Encoder.forProduct5(
     "statusCode",
     "headers",

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResultV2.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResultV2.scala
@@ -18,7 +18,7 @@ package feral.lambda.events
 
 import io.circe.Encoder
 
-final case class ApiGatewayProxyStructuredResultV2(
+sealed abstract case class ApiGatewayProxyStructuredResultV2 private (
     statusCode: Int,
     headers: Map[String, String],
     body: String,
@@ -27,6 +27,21 @@ final case class ApiGatewayProxyStructuredResultV2(
 )
 
 object ApiGatewayProxyStructuredResultV2 {
+  def apply(
+      statusCode: Int,
+      headers: Map[String, String],
+      body: String,
+      isBase64Encoded: Boolean,
+      cookies: List[String]
+  ): ApiGatewayProxyStructuredResultV2 =
+    new ApiGatewayProxyStructuredResultV2(
+      statusCode,
+      headers,
+      body,
+      isBase64Encoded,
+      cookies
+    ) {}
+
   implicit def encoder: Encoder[ApiGatewayProxyStructuredResultV2] = Encoder.forProduct5(
     "statusCode",
     "headers",

--- a/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
@@ -81,7 +81,7 @@ object StreamRecord {
   )(StreamRecord.apply)
 }
 
-final case class DynamoDbRecord(
+sealed abstract case class DynamoDbRecord private (
     awsRegion: Option[String],
     dynamodb: Option[StreamRecord],
     eventID: Option[String],
@@ -93,6 +93,27 @@ final case class DynamoDbRecord(
 )
 
 object DynamoDbRecord {
+  private[lambda] def apply(
+      awsRegion: Option[String],
+      dynamodb: Option[StreamRecord],
+      eventID: Option[String],
+      eventName: Option[String],
+      eventSource: Option[String],
+      eventSourceArn: Option[String],
+      eventVersion: Option[String],
+      userIdentity: Option[Json]
+  ): DynamoDbRecord =
+    new DynamoDbRecord(
+      awsRegion,
+      dynamodb,
+      eventID,
+      eventName,
+      eventSource,
+      eventSourceArn,
+      eventVersion,
+      userIdentity
+    ) {}
+
   implicit val decoder: Decoder[DynamoDbRecord] = Decoder.forProduct8(
     "awsRegion",
     "dynamodb",
@@ -105,11 +126,14 @@ object DynamoDbRecord {
   )(DynamoDbRecord.apply)
 }
 
-final case class DynamoDbStreamEvent(
+sealed abstract case class DynamoDbStreamEvent private (
     records: List[DynamoDbRecord]
 )
 
 object DynamoDbStreamEvent {
+  private[lambda] def apply(records: List[DynamoDbRecord]): DynamoDbStreamEvent =
+    new DynamoDbStreamEvent(records) {}
+
   implicit val decoder: Decoder[DynamoDbStreamEvent] =
     Decoder.forProduct1("Records")(DynamoDbStreamEvent.apply)
 

--- a/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
@@ -23,7 +23,7 @@ import scodec.bits.ByteVector
 
 import java.time.Instant
 
-final case class KinesisStreamRecordPayload(
+sealed abstract case class KinesisStreamRecordPayload private (
     approximateArrivalTimestamp: Instant,
     data: ByteVector,
     kinesisSchemaVersion: String,
@@ -32,6 +32,21 @@ final case class KinesisStreamRecordPayload(
 )
 
 object KinesisStreamRecordPayload {
+  private[lambda] def apply(
+      approximateArrivalTimestamp: Instant,
+      data: ByteVector,
+      kinesisSchemaVersion: String,
+      partitionKey: String,
+      sequenceNumber: String
+  ): KinesisStreamRecordPayload =
+    new KinesisStreamRecordPayload(
+      approximateArrivalTimestamp,
+      data,
+      kinesisSchemaVersion,
+      partitionKey,
+      sequenceNumber
+    ) {}
+
   implicit val decoder: Decoder[KinesisStreamRecordPayload] = Decoder.forProduct5(
     "approximateArrivalTimestamp",
     "data",
@@ -41,7 +56,7 @@ object KinesisStreamRecordPayload {
   )(KinesisStreamRecordPayload.apply)
 }
 
-final case class KinesisStreamRecord(
+sealed abstract case class KinesisStreamRecord private (
     awsRegion: String,
     eventID: String,
     eventName: String,
@@ -53,6 +68,27 @@ final case class KinesisStreamRecord(
 )
 
 object KinesisStreamRecord {
+  private[lambda] def apply(
+      awsRegion: String,
+      eventID: String,
+      eventName: String,
+      eventSource: String,
+      eventSourceArn: String,
+      eventVersion: String,
+      invokeIdentityArn: String,
+      kinesis: KinesisStreamRecordPayload
+  ): KinesisStreamRecord =
+    new KinesisStreamRecord(
+      awsRegion,
+      eventID,
+      eventName,
+      eventSource,
+      eventSourceArn,
+      eventVersion,
+      invokeIdentityArn,
+      kinesis
+    ) {}
+
   implicit val decoder: Decoder[KinesisStreamRecord] = Decoder.forProduct8(
     "awsRegion",
     "eventID",
@@ -65,11 +101,14 @@ object KinesisStreamRecord {
   )(KinesisStreamRecord.apply)
 }
 
-final case class KinesisStreamEvent(
+sealed abstract case class KinesisStreamEvent private (
     records: List[KinesisStreamRecord]
 )
 
 object KinesisStreamEvent {
+  private[lambda] def apply(records: List[KinesisStreamRecord]): KinesisStreamEvent =
+    new KinesisStreamEvent(records) {}
+
   implicit val decoder: Decoder[KinesisStreamEvent] =
     Decoder.forProduct1("Records")(KinesisStreamEvent.apply)
 

--- a/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
@@ -47,6 +47,8 @@ object KinesisStreamRecordPayload {
       sequenceNumber
     ) {}
 
+  private[lambda] def unapply(payload: KinesisStreamRecordPayload): Nothing = ???
+
   implicit val decoder: Decoder[KinesisStreamRecordPayload] = Decoder.forProduct5(
     "approximateArrivalTimestamp",
     "data",
@@ -89,6 +91,8 @@ object KinesisStreamRecord {
       kinesis
     ) {}
 
+  private[lambda] def unapply(record: KinesisStreamRecord): Nothing = ???
+
   implicit val decoder: Decoder[KinesisStreamRecord] = Decoder.forProduct8(
     "awsRegion",
     "eventID",
@@ -108,6 +112,7 @@ sealed abstract case class KinesisStreamEvent private (
 object KinesisStreamEvent {
   private[lambda] def apply(records: List[KinesisStreamRecord]): KinesisStreamEvent =
     new KinesisStreamEvent(records) {}
+  private[lambda] def unapply(event: KinesisStreamEvent): Nothing = ???
 
   implicit val decoder: Decoder[KinesisStreamEvent] =
     Decoder.forProduct1("Records")(KinesisStreamEvent.apply)

--- a/lambda/shared/src/main/scala/feral/lambda/events/S3BatchEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/S3BatchEvent.scala
@@ -42,6 +42,8 @@ object S3BatchEvent {
       tasks
     ) {}
 
+  private[lambda] def unapply(event: S3BatchEvent): Nothing = ???
+
   implicit val decoder: Decoder[S3BatchEvent] =
     Decoder.forProduct4("invocationSchemaVersion", "invocationId", "job", "tasks")(
       S3BatchEvent.apply)

--- a/lambda/shared/src/main/scala/feral/lambda/events/S3BatchEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/S3BatchEvent.scala
@@ -21,7 +21,7 @@ import io.circe.Decoder
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/trigger/s3-batch.d.ts
 
-final case class S3BatchEvent(
+sealed abstract case class S3BatchEvent private (
     invocationSchemaVersion: String,
     invocationId: String,
     job: S3BatchEventJob,
@@ -29,6 +29,19 @@ final case class S3BatchEvent(
 )
 
 object S3BatchEvent {
+  private[lambda] def apply(
+      invocationSchemaVersion: String,
+      invocationId: String,
+      job: S3BatchEventJob,
+      tasks: List[S3BatchEventTask]
+  ): S3BatchEvent =
+    new S3BatchEvent(
+      invocationSchemaVersion,
+      invocationId,
+      job,
+      tasks
+    ) {}
+
   implicit val decoder: Decoder[S3BatchEvent] =
     Decoder.forProduct4("invocationSchemaVersion", "invocationId", "job", "tasks")(
       S3BatchEvent.apply)
@@ -36,20 +49,31 @@ object S3BatchEvent {
   implicit def kernelSource: KernelSource[S3BatchEvent] = KernelSource.emptyKernelSource
 }
 
-final case class S3BatchEventJob(id: String)
+sealed abstract case class S3BatchEventJob private (id: String)
 
 object S3BatchEventJob {
+  private[lambda] def apply(id: String): S3BatchEventJob =
+    new S3BatchEventJob(id) {}
+
   implicit val decoder: Decoder[S3BatchEventJob] =
     Decoder.forProduct1("id")(S3BatchEventJob.apply)
 }
 
-final case class S3BatchEventTask(
+sealed abstract case class S3BatchEventTask private (
     taskId: String,
     s3Key: String,
     s3VersionId: Option[String],
-    s3BucketArn: String)
+    s3BucketArn: String
+)
 
 object S3BatchEventTask {
+  private[lambda] def apply(
+      taskId: String,
+      s3Key: String,
+      s3VersionId: Option[String],
+      s3BucketArn: String
+  ): S3BatchEventTask = new S3BatchEventTask(taskId, s3Key, s3VersionId, s3BucketArn) {}
+
   implicit val decoder: Decoder[S3BatchEventTask] =
     Decoder.forProduct4("taskId", "s3Key", "s3VersionId", "s3BucketArn")(S3BatchEventTask.apply)
 }

--- a/lambda/shared/src/main/scala/feral/lambda/events/S3BatchResult.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/S3BatchResult.scala
@@ -36,6 +36,8 @@ object S3BatchResult {
   ): S3BatchResult =
     new S3BatchResult(invocationSchemaVersion, treatMissingKeysAs, invocationId, results) {}
 
+  private[lambda] def unapply(result: S3BatchResult): Nothing = ???
+
   implicit val encoder: Encoder[S3BatchResult] =
     Encoder.forProduct4(
       "invocationSchemaVersion",

--- a/lambda/shared/src/main/scala/feral/lambda/events/S3BatchResult.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/S3BatchResult.scala
@@ -20,7 +20,7 @@ import io.circe.Encoder
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/trigger/s3-batch.d.ts
 
-final case class S3BatchResult(
+sealed abstract case class S3BatchResult private (
     invocationSchemaVersion: String,
     treatMissingKeysAs: S3BatchResultResultCode,
     invocationId: String,
@@ -28,6 +28,14 @@ final case class S3BatchResult(
 )
 
 object S3BatchResult {
+  private[lambda] def apply(
+      invocationSchemaVersion: String,
+      treatMissingKeysAs: S3BatchResultResultCode,
+      invocationId: String,
+      results: List[S3BatchResultResult]
+  ): S3BatchResult =
+    new S3BatchResult(invocationSchemaVersion, treatMissingKeysAs, invocationId, results) {}
+
   implicit val encoder: Encoder[S3BatchResult] =
     Encoder.forProduct4(
       "invocationSchemaVersion",
@@ -37,7 +45,7 @@ object S3BatchResult {
       (r.invocationSchemaVersion, r.treatMissingKeysAs, r.invocationId, r.results))
 }
 
-sealed abstract class S3BatchResultResultCode
+sealed abstract class S3BatchResultResultCode extends Product with Serializable
 
 object S3BatchResultResultCode {
   case object Succeeded extends S3BatchResultResultCode
@@ -51,12 +59,19 @@ object S3BatchResultResultCode {
   }
 }
 
-final case class S3BatchResultResult(
+sealed abstract case class S3BatchResultResult private (
     taskId: String,
     resultCode: S3BatchResultResultCode,
-    resultString: String)
+    resultString: String
+)
 
 object S3BatchResultResult {
+  private[lambda] def apply(
+      taskId: String,
+      resultCode: S3BatchResultResultCode,
+      resultString: String
+  ): S3BatchResultResult = new S3BatchResultResult(taskId, resultCode, resultString) {}
+
   implicit val encoder: Encoder[S3BatchResultResult] =
     Encoder.forProduct3("taskId", "resultCode", "resultString")(r =>
       (r.taskId, r.resultCode, r.resultString))

--- a/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SnsEvent.scala
@@ -34,6 +34,8 @@ object SnsEvent {
   private[lambda] def apply(records: List[SnsEventRecord]): SnsEvent =
     new SnsEvent(records) {}
 
+  private[lambda] def unapply(event: SnsEvent): Nothing = ???
+
   implicit val decoder: Decoder[SnsEvent] =
     Decoder.forProduct1("Records")(SnsEvent.apply)
 }
@@ -53,6 +55,8 @@ object SnsEventRecord {
       sns: SnsMessage
   ): SnsEventRecord =
     new SnsEventRecord(eventVersion, eventSubscriptionArn, eventSource, sns) {}
+
+  private[lambda] def unapply(record: SnsEventRecord): Nothing = ???
 
   implicit val decoder: Decoder[SnsEventRecord] = Decoder.forProduct4(
     "EventVersion",
@@ -104,6 +108,8 @@ object SnsMessage {
       subject
     ) {}
 
+  private[lambda] def unapply(message: SnsMessage): Nothing = ???
+
   private[this] implicit val instantDecoder: Decoder[Instant] = Decoder.decodeInstant
 
   implicit val decoder: Decoder[SnsMessage] = Decoder.forProduct11(
@@ -128,18 +134,21 @@ object SnsMessageAttribute {
   object String {
     private[lambda] def apply(value: Predef.String): String =
       new String(value) {}
+    private[lambda] def unapply(string: String): Nothing = ???
   }
 
   sealed abstract case class Binary private (value: ByteVector) extends SnsMessageAttribute
   object Binary {
     private[lambda] def apply(value: ByteVector): Binary =
       new Binary(value) {}
+    private[lambda] def unapply(binary: Binary): Nothing = ???
   }
 
   sealed abstract case class Number private (value: BigDecimal) extends SnsMessageAttribute
   object Number {
     private[lambda] def apply(value: BigDecimal): Number =
       new Number(value) {}
+    private[lambda] def unapply(number: Number): Nothing = ???
   }
 
   sealed abstract case class StringArray private (value: List[SnsMessageAttributeArrayMember])
@@ -147,6 +156,7 @@ object SnsMessageAttribute {
   object StringArray {
     private[lambda] def apply(value: List[SnsMessageAttributeArrayMember]): StringArray =
       new StringArray(value) {}
+    private[lambda] def unapply(stringArray: StringArray): Nothing = ???
   }
 
   sealed abstract case class Unknown private (
@@ -158,6 +168,7 @@ object SnsMessageAttribute {
         `type`: Predef.String,
         value: Option[Predef.String]
     ): Unknown = new Unknown(`type`, value) {}
+    private[lambda] def unapply(unknown: Unknown): Nothing = ???
   }
 
   implicit val decoder: Decoder[SnsMessageAttribute] = {
@@ -199,6 +210,7 @@ object SnsMessageAttributeArrayMember {
   object String {
     private[lambda] def apply(value: Predef.String): String =
       new String(value) {}
+    private[lambda] def unapply(string: String): Nothing = ???
   }
 
   sealed abstract case class Number private (value: BigDecimal)
@@ -206,6 +218,7 @@ object SnsMessageAttributeArrayMember {
   object Number {
     private[lambda] def apply(value: BigDecimal): Number =
       new Number(value) {}
+    private[lambda] def unapply(number: Number): Nothing = ???
   }
 
   sealed abstract case class Boolean private (value: scala.Boolean)
@@ -213,6 +226,7 @@ object SnsMessageAttributeArrayMember {
   object Boolean {
     private[lambda] def apply(value: scala.Boolean): Boolean =
       new Boolean(value) {}
+    private[lambda] def unapply(boolean: Boolean): Nothing = ???
   }
 
   implicit val decoder: Decoder[SnsMessageAttributeArrayMember] = {

--- a/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
@@ -35,6 +35,7 @@ sealed abstract case class SqsEvent private (
 object SqsEvent {
   private[lambda] def apply(records: List[SqsRecord]): SqsEvent =
     new SqsEvent(records) {}
+  private[lambda] def unapply(event: SqsEvent): Nothing = ???
 
   implicit val decoder: Decoder[SqsEvent] =
     Decoder.instance(_.get[List[SqsRecord]]("Records")).map(SqsEvent(_))
@@ -75,6 +76,8 @@ object SqsRecord {
       eventSourceArn,
       awsRegion
     ) {}
+
+  private[lambda] def unapply(record: SqsRecord): Nothing = ???
 
   implicit val decoder: Decoder[SqsRecord] = Decoder.instance(i =>
     for {
@@ -133,6 +136,8 @@ object SqsRecordAttributes {
       messageDeduplicationId
     ) {}
 
+  private[lambda] def unapply(attributes: SqsRecordAttributes): Nothing = ???
+
   implicit val decoder: Decoder[SqsRecordAttributes] = Decoder.instance(i =>
     for {
       awsTraceHeader <- i.get[Option[String]]("AWSTraceHeader")
@@ -164,18 +169,21 @@ object SqsMessageAttribute {
   object String {
     private[lambda] def apply(value: Predef.String): String =
       new String(value) {}
+    private[lambda] def unapply(string: String): Nothing = ???
   }
 
   sealed abstract case class Binary private (value: ByteVector) extends SqsMessageAttribute
   object Binary {
     private[lambda] def apply(value: ByteVector): Binary =
       new Binary(value) {}
+    private[lambda] def unapply(binary: Binary): Nothing = ???
   }
 
   sealed abstract case class Number private (value: BigDecimal) extends SqsMessageAttribute
   object Number {
     private[lambda] def apply(value: BigDecimal): Number =
       new Number(value) {}
+    private[lambda] def unapply(number: Number): Nothing = ???
   }
 
   sealed abstract case class Unknown(
@@ -189,6 +197,8 @@ object SqsMessageAttribute {
         binaryValue: Option[Predef.String],
         dataType: Predef.String
     ): Unknown = new Unknown(stringValue, binaryValue, dataType) {}
+
+    private[lambda] def unapply(unknown: Unknown): Nothing = ???
   }
 
   implicit val decoder: Decoder[SqsMessageAttribute] = {


### PR DESCRIPTION
`sealed abstract case class`es don't have `apply`  or `copy` methods, but still have nice `toString`, `hashCode`, and `equals`.

Unfortunately they still generate `unapply` methods, so I've overridden those with package-private implementations to prevent the public one from being generated.

I've made the `apply` methods for events package-private. In ordinary use they should not be necessary, and importantly it protects our bincompat should AWS decide to add more non-optional fields, which technically they can do backwards-compatibly at any time.

Then, we can expose `apply` methods in the testkit like I propose doing for `Context` in https://github.com/typelevel/feral/pull/247. This will enable them to be mocked.

I didn't finish the DynamoDB-related stuff, I think I might like to make some bigger changes there in a followup.