### PR TITLE
Make `Decoder[Instant]` explicit

### DIFF
--- a/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
@@ -32,6 +32,7 @@ final case class KinesisStreamRecordPayload(
 )
 
 object KinesisStreamRecordPayload {
+  implicit private val instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
   implicit val decoder: Decoder[KinesisStreamRecordPayload] = Decoder.forProduct5(
     "approximateArrivalTimestamp",
     "data",

--- a/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
@@ -32,7 +32,7 @@ final case class KinesisStreamRecordPayload(
 )
 
 object KinesisStreamRecordPayload {
-  implicit private val instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
+  implicit private def instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
   implicit val decoder: Decoder[KinesisStreamRecordPayload] = Decoder.forProduct5(
     "approximateArrivalTimestamp",
     "data",

--- a/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
@@ -88,7 +88,7 @@ final case class SqsRecordAttributes(
 
 object SqsRecordAttributes {
 
-  implicit private val instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
+  implicit private def instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
 
   implicit val decoder: Decoder[SqsRecordAttributes] = Decoder.instance(i =>
     for {

--- a/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
@@ -88,6 +88,8 @@ final case class SqsRecordAttributes(
 
 object SqsRecordAttributes {
 
+  implicit private val instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
+
   implicit val decoder: Decoder[SqsRecordAttributes] = Decoder.instance(i =>
     for {
       awsTraceHeader <- i.get[Option[String]]("AWSTraceHeader")

--- a/lambda/shared/src/main/scala/feral/lambda/events/package.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/package.scala
@@ -23,7 +23,7 @@ import scala.util.Try
 
 package object events {
 
-  implicit lazy val instantDecoder: Decoder[Instant] =
+  lazy val instantDecoder: Decoder[Instant] =
     Decoder.decodeBigDecimal.emapTry { millis =>
       def round(x: BigDecimal) = x.setScale(0, BigDecimal.RoundingMode.DOWN)
       Try {

--- a/lambda/shared/src/test/scala/feral/lambda/events/InstantDecoderSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/InstantDecoderSuite.scala
@@ -16,7 +16,7 @@
 
 package feral.lambda.events
 
-import io.circe.Json
+import io.circe.{Decoder, Json}
 import munit.ScalaCheckSuite
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen
@@ -25,6 +25,8 @@ import org.scalacheck.Prop.forAll
 import java.time.Instant
 
 class InstantDecoderSuite extends ScalaCheckSuite {
+
+  implicit private val instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
 
   implicit val arbitraryInstant: Arbitrary[Instant] = Arbitrary(
     Gen.long.map(Instant.ofEpochMilli(_)))

--- a/lambda/shared/src/test/scala/feral/lambda/events/InstantDecoderSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/InstantDecoderSuite.scala
@@ -26,7 +26,7 @@ import java.time.Instant
 
 class InstantDecoderSuite extends ScalaCheckSuite {
 
-  implicit private val instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
+  implicit private def instantDecoder: Decoder[Instant] = feral.lambda.events.instantDecoder
 
   implicit val arbitraryInstant: Arbitrary[Instant] = Arbitrary(
     Gen.long.map(Instant.ofEpochMilli(_)))


### PR DESCRIPTION
Preparation for #354 

If this gets merged before #354, #354 should be updated to remove the explicit references to `io.circe.Decoder.decodeInstant`.

If #354 gets merged before this one, this one should be updated to remove those references to `io.circe.Decoder.decodeInstant` in `S3EventRecord` and `S3EventRecordGlacierRestoreEventData`.