### PR TITLE
Use `ByteVector` for B and BS in DynamoDbStreamEvent

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ import com.typesafe.tools.mima.core._
 
 name := "feral"
 
-ThisBuild / tlBaseVersion := "0.2"
+ThisBuild / tlBaseVersion := "0.3"
 ThisBuild / startYear := Some(2021)
 
 ThisBuild / developers := List(

--- a/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
@@ -19,10 +19,12 @@ package events
 
 import io.circe.Decoder
 import io.circe.Json
+import io.circe.scodec.decodeByteVector
+import scodec.bits.ByteVector
 
 final case class AttributeValue(
-    b: Option[String],
-    bs: Option[String],
+    b: Option[ByteVector],
+    bs: Option[List[ByteVector]],
     bool: Option[Boolean],
     l: Option[List[AttributeValue]],
     m: Option[Map[String, AttributeValue]],
@@ -35,8 +37,8 @@ final case class AttributeValue(
 
 object AttributeValue {
   implicit val decoder: Decoder[AttributeValue] = for {
-    b <- Decoder[Option[String]].at("B")
-    bs <- Decoder[Option[String]].at("BS")
+    b <- Decoder[Option[ByteVector]].at("B")
+    bs <- Decoder[Option[List[ByteVector]]].at("BS")
     bool <- Decoder[Option[Boolean]].at("BOOL")
     l <- Decoder[Option[List[AttributeValue]]].at("L")
     m <- Decoder[Option[Map[String, AttributeValue]]].at("M")

--- a/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
@@ -45,7 +45,7 @@ class DynamoDbStreamEventSuite extends FunSuite {
 
   test("AttributeValue should decode a BS") {
 
-    val vector = ByteVector.view("foo".getBytes(StandardCharsets.UTF_8))
+    val vector = utf8Bytes"foo"
 
     val source = json"""
       {

--- a/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
@@ -43,7 +43,7 @@ class DynamoDbStreamEventSuite extends FunSuite {
     assertEquals(decoded, vector.some)
   }
 
-  test("AttributeValue should decod a BS") {
+  test("AttributeValue should decode a BS") {
 
     val vector = ByteVector.view("foo".getBytes(StandardCharsets.UTF_8))
 

--- a/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
@@ -80,7 +80,14 @@ class DynamoDbStreamEventSuite extends FunSuite {
               "N": "101"
             },
             "Image": {
-              "B": ""
+              "B": "iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII"
+            },
+            "Images": {
+              "BS": [
+                "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQz0AEYBxVSF+FABJADveWkH6oAAAAAElFTkSuQmCC",
+                "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNk+M9Qz0AEYBxVSF+FAAhKDveksOjmAAAAAElFTkSuQmCC",
+                "iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mNkYPhfz0AEYBxVSF+FAP5FDvcfRYWgAAAAAElFTkSuQmCC"
+              ]
             }
           },
           "StreamViewType": "NEW_AND_OLD_IMAGES",

--- a/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
@@ -19,8 +19,7 @@ package feral.lambda.events
 import cats.syntax.option._
 import io.circe.literal._
 import munit.FunSuite
-import java.nio.charset.StandardCharsets
-import scodec.bits.ByteVector
+import scodec.bits._
 
 class DynamoDbStreamEventSuite extends FunSuite {
 

--- a/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
@@ -28,7 +28,7 @@ class DynamoDbStreamEventSuite extends FunSuite {
     event.as[DynamoDbStreamEvent].toTry.get
   }
 
-  test("AttributeValue should decod a B") {
+  test("AttributeValue should decode a B") {
 
     val vector = ByteVector.view("foo".getBytes(StandardCharsets.UTF_8))
 

--- a/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/DynamoDbStreamEventSuite.scala
@@ -30,7 +30,7 @@ class DynamoDbStreamEventSuite extends FunSuite {
 
   test("AttributeValue should decode a B") {
 
-    val vector = ByteVector.view("foo".getBytes(StandardCharsets.UTF_8))
+    val vector = utf8Bytes"foo"
 
     val source = json"""
       {


### PR DESCRIPTION
This changes the decoding and representation of  the DynamoDb AttributeValue B and BS. Also this solves a big where the BS DynamoDB AttributeValue BS type was modelled as a single String that would fail the decoding.

B is a binary value Base64 encoded on the wire, while BS is an ordered set of binary base64 encoded value. 

Given that feral depends already on scodec, it makes sense to use BinaryVector to model the binary value.
