### PR TITLE
Organize imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,10 @@ jobs:
         if: matrix.java == 'corretto@8' && matrix.os == 'ubuntu-latest'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
+      - name: Check scalafix lints
+        if: matrix.java == 'corretto@8' && matrix.os == 'ubuntu-latest'
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' 'scalafixAll --check'
+
       - name: scalaJSLink
         if: matrix.project == 'rootJS'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/scalaJSLinkerResult

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,2 @@
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false

--- a/core/src/main/scala/feral/IOSetup.scala
+++ b/core/src/main/scala/feral/IOSetup.scala
@@ -16,13 +16,13 @@
 
 package feral
 
-import scala.concurrent.Future
-
-import cats.effect.unsafe.IORuntime
-import cats.effect.kernel.Resource
 import cats.effect.IO
+import cats.effect.kernel.Resource
 import cats.effect.std.Dispatcher
+import cats.effect.unsafe.IORuntime
 import cats.syntax.all._
+
+import scala.concurrent.Future
 
 private[feral] trait IOSetup {
 

--- a/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
+++ b/lambda-cloudformation-custom-resource/src/test/scala/feral/lambda/cloudformation/CloudFormationCustomResourceArbitraries.scala
@@ -20,12 +20,15 @@ package cloudformation
 import cats._
 import cats.syntax.all._
 import feral.lambda.cloudformation.CloudFormationRequestType._
-import io.circe.{Json, JsonObject}
-import io.circe.testing.instances.{arbitraryJson, arbitraryJsonObject}
-import org.http4s.{Charset => _, _}
+import io.circe.Json
+import io.circe.JsonObject
+import io.circe.testing.instances.arbitraryJson
+import io.circe.testing.instances.arbitraryJsonObject
 import org.http4s.syntax.all._
+import org.http4s.{Charset => _, _}
+import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.Gen
 
 import java.nio.charset.Charset
 import java.util.UUID

--- a/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
+++ b/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
@@ -25,7 +25,8 @@ import fs2.Stream
 import org.http4s.Charset
 import org.http4s.Header
 import org.http4s.Headers
-import org.http4s.{HttpApp, HttpRoutes}
+import org.http4s.HttpApp
+import org.http4s.HttpRoutes
 import org.http4s.Method
 import org.http4s.Request
 import org.http4s.Uri

--- a/lambda-http4s/src/test/scala-2/feral/lambda/http4s/ApiGatewayProxyHandlerSuite.scala
+++ b/lambda-http4s/src/test/scala-2/feral/lambda/http4s/ApiGatewayProxyHandlerSuite.scala
@@ -21,9 +21,9 @@ import cats.syntax.all._
 import feral.lambda.events.ApiGatewayProxyEventV2
 import feral.lambda.events.ApiGatewayProxyEventV2Suite
 import munit.CatsEffectSuite
+import org.http4s.Headers
 import org.http4s.Method
 import org.http4s.syntax.all._
-import org.http4s.Headers
 
 class ApiGatewayProxyHandlerSuite extends CatsEffectSuite {
 

--- a/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
+++ b/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
@@ -16,9 +16,6 @@
 
 package feral.lambda
 
-import scala.concurrent.Await
-import scala.concurrent.duration.Duration
-
 import cats.data.OptionT
 import cats.effect.IO
 import cats.effect.kernel.Resource
@@ -30,6 +27,8 @@ import io.circe.syntax._
 import java.io.InputStream
 import java.io.OutputStream
 import java.io.OutputStreamWriter
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 private[lambda] abstract class IOLambdaPlatform[Event, Result]
     extends lambdaRuntime.RequestStreamHandler { this: IOLambda[Event, Result] =>

--- a/lambda/shared/src/main/scala/feral/lambda/Context.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/Context.scala
@@ -16,8 +16,8 @@
 
 package feral.lambda
 
-import cats.~>
 import cats.Applicative
+import cats.~>
 import io.circe.JsonObject
 
 import scala.concurrent.duration.FiniteDuration

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.6.2")
+val sbtlTlV = "0.6.2"
+addSbtPlugin("org.typelevel" % "sbt-typelevel" % sbtlTlV)
+addSbtPlugin("org.typelevel" % "sbt-typelevel-scalafix" % sbtlTlV)
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.14.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")


### PR DESCRIPTION
I think this is a nice thing to do, but the catalyst is setting up the `sbt-typelevel-scalafix` plugin which will help us with https://github.com/typelevel/feral/issues/428.