### PR TITLE
Add deprecated aliases for renamed stuff

### DIFF
--- a/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
@@ -152,6 +152,9 @@ sealed abstract class DynamoDbRecord {
   def eventSourceArn: Option[String]
   def eventVersion: Option[String]
   def userIdentity: Option[Json]
+
+  @deprecated("0.3.0", "Renamed to eventId")
+  final def eventID: Option[String] = eventId
 }
 
 object DynamoDbRecord {

--- a/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
@@ -77,6 +77,9 @@ sealed abstract class KinesisStreamRecord {
   def eventVersion: String
   def invokeIdentityArn: String
   def kinesis: KinesisStreamRecordPayload
+
+  @deprecated("0.3.0", "Renamed to eventId")
+  final def eventID: String = eventId
 }
 
 object KinesisStreamRecord {

--- a/lambda/shared/src/main/scala/feral/lambda/events/package.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/package.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feral.lambda
+
+package object events {
+
+  @deprecated("0.3.0", "Renamed to ApiGatewayProxyEvent")
+  type APIGatewayProxyRequestEvent = ApiGatewayProxyEvent
+  @deprecated("0.3.0", "Renamed to ApiGatewayProxyEvent")
+  val APIGatewayProxyRequestEvent = ApiGatewayProxyEvent
+
+  @deprecated("0.3.0", "Renamed to ApiGatewayProxyResult")
+  type APIGatewayProxyResponseEvent = ApiGatewayProxyResult
+  @deprecated("0.3.0", "Renamed to ApiGatewayProxyResult")
+  val APIGatewayProxyResponseEvent = ApiGatewayProxyResult
+
+}


### PR DESCRIPTION
Should have added these in https://github.com/typelevel/feral/pull/425.