### PR TITLE
Optimize `IOLambda#handleRequest` on JVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,7 +122,6 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
       "co.fs2" %%% "fs2-io" % fs2Version,
-      "io.circe" %%% "circe-fs2" % "0.14.1"
     )
   )
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -121,7 +121,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
   .jvmSettings(
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
-      "co.fs2" %%% "fs2-io" % fs2Version,
+      "co.fs2" %%% "fs2-io" % fs2Version
     )
   )
   .dependsOn(core)

--- a/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
+++ b/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
@@ -47,13 +47,13 @@ private[lambda] abstract class IOLambdaPlatform[Event, Result]
       val context = IO(Context.fromJava[IO](runtimeContext))
 
       (event, context).flatMapN(lambda(_, _)).flatMap {
-        _.traverse_ { result =>
+        case Some(result) =>
           IO {
             val writer = new OutputStreamWriter(output)
             Printer.noSpaces.unsafePrintToAppendable(result.asJson, writer)
             writer.flush()
           }
-        }
+        case None => IO.unit
       }
     }
   }

--- a/lambda/jvm/src/test/scala/feral/lambda/IOLambdaJvmSuite.scala
+++ b/lambda/jvm/src/test/scala/feral/lambda/IOLambdaJvmSuite.scala
@@ -62,7 +62,7 @@ class IOLambdaJvmSuite extends FunSuite {
     override def getInvokedFunctionArn(): String = ""
     override def getIdentity(): runtime.CognitoIdentity = null
     override def getClientContext(): runtime.ClientContext = null
-    override def getRemainingTimeInMillis(): Int = 0
+    override def getRemainingTimeInMillis(): Int = Int.MaxValue
     override def getMemoryLimitInMB(): Int = 0
     override def getLogger(): runtime.LambdaLogger = null
   }


### PR DESCRIPTION
If we assume* that the `InputStream` and `OutputStream` passed to the handler are a `ByteArrayInputStream` and a `ByteArrayOutputStream` then we can take advantage of the fact that they are non-blocking and actually non-streaming. ~~(In the unlikely case that this assumption is wrong, blocking on the compute before/after the handler seems pretty harmless anyway, since there is no concurrency).~~

This also allows us to drop the circe-fs2 dependency which is [deprecated](https://github.com/circe/circe-fs2#deprecated).

\* FTR:
- https://github.com/aws/aws-lambda-java-libs/blob/3d8dfb66f3a852bf69618bd5f66222692f1f5a49/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/runtimeapi/InvocationRequest.java#L94-L96
- https://github.com/aws/aws-lambda-java-libs/blob/3d8dfb66f3a852bf69618bd5f66222692f1f5a49/aws-lambda-java-runtime-interface-client/src/main/java/com/amazonaws/services/lambda/runtime/api/client/AWSLambda.java#L243-L245