### PR TITLE
Implement workaround for initialization order errors in JVM lambdas

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,6 +109,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .jvmSettings(
+    Test / fork := true,
     libraryDependencies ++= Seq(
       "com.amazonaws" % "aws-lambda-java-core" % "1.2.3",
       "co.fs2" %%% "fs2-io" % fs2Version

--- a/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
+++ b/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
@@ -43,8 +43,9 @@ private[lambda] abstract class IOLambdaPlatform[Event, Result]
         try this.handler
         catch { case ex if NonFatal(ex) => null }
 
-      if (h ne null) { h.map(IO.pure(_)) }
-      else {
+      if (h ne null) {
+        h.map(IO.pure(_))
+      } else {
         val lambdaName = getClass().getSimpleName()
         val msg =
           s"""|There was an error initializing `$lambdaName` during startup.
@@ -52,10 +53,7 @@ private[lambda] abstract class IOLambdaPlatform[Event, Result]
               |To fix, try replacing any `val`s in `$lambdaName` with `def`s.""".stripMargin
         System.err.println(msg)
 
-        Async[Resource[IO, *]].defer(this.handler).memoize.map {
-          case Resource.Eval(ioa) => ioa
-          case _ => throw new AssertionError
-        }
+        Async[Resource[IO, *]].defer(this.handler).memoize.map(_.allocated.map(_._1))
       }
     }
 

--- a/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
+++ b/lambda/jvm/src/main/scala/feral/lambda/IOLambdaPlatform.scala
@@ -16,8 +16,11 @@
 
 package feral.lambda
 
+import cats.effect.Async
 import cats.effect.IO
+import cats.effect.Resource
 import cats.effect.std.Dispatcher
+import cats.effect.syntax.all._
 import cats.syntax.all._
 import com.amazonaws.services.lambda.{runtime => lambdaRuntime}
 import io.circe.Printer
@@ -29,11 +32,33 @@ import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.nio.channels.Channels
 import scala.concurrent.duration._
+import scala.util.control.NonFatal
 
 private[lambda] abstract class IOLambdaPlatform[Event, Result]
     extends lambdaRuntime.RequestStreamHandler { this: IOLambda[Event, Result] =>
 
   private[this] val (dispatcher, handle) = {
+    val handler = {
+      val h =
+        try this.handler
+        catch { case ex if NonFatal(ex) => null }
+
+      if (h ne null) { h.map(IO.pure(_)) }
+      else {
+        val lambdaName = getClass().getSimpleName()
+        val msg =
+          s"""|There was an error initializing `$lambdaName` during startup.
+              |Falling back to initialize-during-first-invocation strategy.
+              |To fix, try replacing any `val`s in `$lambdaName` with `def`s.""".stripMargin
+        System.err.println(msg)
+
+        Async[Resource[IO, *]].defer(this.handler).memoize.map {
+          case Resource.Eval(ioa) => ioa
+          case _ => throw new AssertionError
+        }
+      }
+    }
+
     Dispatcher
       .parallel[IO](await = false)
       .product(handler)
@@ -50,7 +75,7 @@ private[lambda] abstract class IOLambdaPlatform[Event, Result]
     val context = Context.fromJava[IO](runtimeContext)
     dispatcher
       .unsafeRunTimed(
-        handle(Invocation.pure(event, context)),
+        handle.flatMap(_(Invocation.pure(event, context))),
         runtimeContext.getRemainingTimeInMillis().millis
       )
       .foreach { result =>

--- a/lambda/jvm/src/test/scala/feral/lambda/IOLambdaJvmSuite.scala
+++ b/lambda/jvm/src/test/scala/feral/lambda/IOLambdaJvmSuite.scala
@@ -83,6 +83,31 @@ class IOLambdaJvmSuite extends FunSuite {
     )
   }
 
+  test("gracefully handles broken initialization due to `val`") {
+    val os = new ByteArrayOutputStream
+
+    val lambda1 = new IOLambda[Unit, Unit] {
+      val handler = Resource.pure(_ => IO(None))
+    }
+
+    lambda1.handleRequest(
+      new ByteArrayInputStream("{}".getBytes()),
+      os,
+      DummyContext
+    )
+
+    val lambda2 = new IOLambda[Unit, Unit] {
+      def handler = resource.as(_ => IO(None))
+      val resource = Resource.unit[IO]
+    }
+
+    lambda2.handleRequest(
+      new ByteArrayInputStream("{}".getBytes()),
+      os,
+      DummyContext
+    )
+  }
+
   object DummyContext extends runtime.Context {
     override def getAwsRequestId(): String = ""
     override def getLogGroupName(): String = ""


### PR DESCRIPTION
Fixes a regression [reported on Discord](https://discord.com/channels/632277896739946517/918373380003082250/1196217785781592105).

Previously, `IOLambda` was not sensitive to whether initializing the `handler` involved `val`s. This is because the definition of `handler` was used lazily on the first invocation of the lambda, not during its construction.

However, after the changes in https://github.com/typelevel/feral/pull/446, we now use the definition of `handler` eagerly during construction. A `val` in a superclass (i.e. `IOLambda`) is always initialized before `val`s in the subclass (i.e. user-defined `FooLambda`). This means that all `val`s in the subclass are uninitialized (i.e. `null`) when we initialize `val handle` in `IOLambda`.

The proper remedy for this situation is that users should always use `def` instead of `val` in their `IOLambda`s. However, because this is a highly surprising regression wrt the previous behavior, we now make a best-effort to detect this situation, log an actionable warning, and fallback to the old semantic where we initialize during the first invocation of the lambda.

```
There was an error initializing `FooLambda` during startup.
Falling back to initialize-during-first-invocation strategy.
To fix, try replacing any `val`s in `FooLambda` with `def`s.
```

I've published this PR as `0.3-97de28d-SNAPSHOT`.