### PR TITLE
Extract lambda-natchez module

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,11 +133,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p lambda-cloudformation-custom-resource/.js/target lambda-http4s/.jvm/target unidocs/target lambda-http4s/.js/target lambda/js/target scalafix/rules/target lambda/jvm/target sbt-lambda/target lambda-cloudformation-custom-resource/.jvm/target project/target
+        run: mkdir -p lambda-natchez/jvm/target lambda-natchez/js/target lambda-cloudformation-custom-resource/.js/target lambda-http4s/.jvm/target unidocs/target lambda-http4s/.js/target lambda/js/target scalafix/rules/target lambda/jvm/target sbt-lambda/target lambda-cloudformation-custom-resource/.jvm/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar lambda-cloudformation-custom-resource/.js/target lambda-http4s/.jvm/target unidocs/target lambda-http4s/.js/target lambda/js/target scalafix/rules/target lambda/jvm/target sbt-lambda/target lambda-cloudformation-custom-resource/.jvm/target project/target
+        run: tar cf targets.tar lambda-natchez/jvm/target lambda-natchez/js/target lambda-cloudformation-custom-resource/.js/target lambda-http4s/.jvm/target unidocs/target lambda-http4s/.js/target lambda/js/target scalafix/rules/target lambda/jvm/target sbt-lambda/target lambda-cloudformation-custom-resource/.jvm/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val lambda = crossProject(JSPlatform, JVMPlatform)
     name := "feral-lambda",
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
-      "org.tpolecat" %%% "natchez-core" % natchezVersion,
+      "org.typelevel" %%% "case-insensitive" % "1.4.0",
       "io.circe" %%% "circe-scodec" % circeVersion,
       "io.circe" %%% "circe-jawn" % circeVersion,
       "com.comcast" %%% "ip4s-core" % "3.4.0",

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,7 @@ lazy val root =
   tlCrossRootProject
     .aggregate(
       lambda,
+      lambdaNatchez,
       lambdaHttp4s,
       lambdaCloudFormationCustomResource,
       examples,
@@ -170,6 +171,19 @@ lazy val lambdaCloudFormationCustomResource = crossProject(JSPlatform, JVMPlatfo
   .settings(commonSettings)
   .dependsOn(lambda)
 
+lazy val lambdaNatchez = crossProject(JSPlatform, JVMPlatform)
+  .in(file("lambda-natchez"))
+  .settings(
+    name := "feral-lambda-natchez",
+    libraryDependencies ++= Seq(
+      "org.tpolecat" %%% "natchez-core" % natchezVersion,
+      "org.scalameta" %%% "munit-scalacheck" % munitVersion % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % munitCEVersion % Test
+    )
+  )
+  .settings(commonSettings)
+  .dependsOn(lambda)
+
 lazy val examples = crossProject(JSPlatform, JVMPlatform)
   .crossType(CrossType.Pure)
   .in(file("examples"))
@@ -183,7 +197,7 @@ lazy val examples = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .settings(commonSettings)
-  .dependsOn(lambda, lambdaHttp4s)
+  .dependsOn(lambda, lambdaNatchez, lambdaHttp4s)
   .enablePlugins(NoPublishPlugin)
 
 lazy val unidocs = project

--- a/examples/src/main/scala/feral/examples/Http4sLambda.scala
+++ b/examples/src/main/scala/feral/examples/Http4sLambda.scala
@@ -16,14 +16,15 @@
 
 package feral.examples
 
+import _root_.natchez.Trace
+import _root_.natchez.http4s.NatchezMiddleware
+import _root_.natchez.xray.XRay
 import cats.effect._
 import cats.effect.std.Random
 import feral.lambda._
 import feral.lambda.events._
 import feral.lambda.http4s._
-import natchez.Trace
-import natchez.http4s.NatchezMiddleware
-import natchez.xray.XRay
+import feral.lambda.natchez._
 import org.http4s.HttpApp
 import org.http4s.HttpRoutes
 import org.http4s.client.Client

--- a/examples/src/main/scala/feral/examples/KinesisLambda.scala
+++ b/examples/src/main/scala/feral/examples/KinesisLambda.scala
@@ -16,12 +16,13 @@
 
 package feral.examples
 
+import _root_.natchez.Trace
+import _root_.natchez.xray.XRay
 import cats.effect._
 import cats.effect.std.Random
 import feral.lambda._
 import feral.lambda.events.SqsEvent
-import natchez.Trace
-import natchez.xray.XRay
+import feral.lambda.natchez._
 import skunk.Session
 
 /**

--- a/examples/src/main/scala/feral/examples/KinesisLambda.scala
+++ b/examples/src/main/scala/feral/examples/KinesisLambda.scala
@@ -22,7 +22,6 @@ import cats.effect._
 import cats.effect.std.Random
 import feral.lambda._
 import feral.lambda.events.SqsEvent
-import feral.lambda.natchez._
 import skunk.Session
 
 /**

--- a/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/AwsTags.scala
+++ b/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/AwsTags.scala
@@ -14,16 +14,12 @@
  * limitations under the License.
  */
 
-package feral.lambda
+package feral.lambda.natchez
 
-import natchez.Kernel
+import natchez.TraceValue
 
-trait KernelSource[Event] {
-  def extract(event: Event): Kernel
-}
-
-object KernelSource {
-  @inline def apply[E](implicit ev: KernelSource[E]): ev.type = ev
-
-  def emptyKernelSource[E]: KernelSource[E] = _ => Kernel(Map.empty)
+object AwsTags {
+  private[this] val prefix = "aws"
+  def arn(s: String): (String, TraceValue) = s"$prefix.arn" -> s
+  def requestId(s: String): (String, TraceValue) = s"$prefix.requestId" -> s
 }

--- a/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/KernelSource.scala
+++ b/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/KernelSource.scala
@@ -14,12 +14,16 @@
  * limitations under the License.
  */
 
-package feral.lambda
+package feral.lambda.natchez
 
-import natchez.TraceValue
+import natchez.Kernel
 
-object AwsTags {
-  private[this] val prefix = "aws"
-  def arn(s: String): (String, TraceValue) = s"$prefix.arn" -> s
-  def requestId(s: String): (String, TraceValue) = s"$prefix.requestId" -> s
+trait KernelSource[Event] {
+  def extract(event: Event): Kernel
+}
+
+object KernelSource {
+  @inline def apply[E](implicit ev: KernelSource[E]): ev.type = ev
+
+  def emptyKernelSource[E]: KernelSource[E] = _ => Kernel(Map.empty)
 }

--- a/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/TracedHandler.scala
+++ b/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/TracedHandler.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package feral.lambda
+package feral.lambda.natchez
 
 import cats.data.Kleisli
 import cats.effect.IO
 import cats.effect.kernel.MonadCancelThrow
 import cats.syntax.all._
+import feral.lambda.Invocation
 import natchez.EntryPoint
 import natchez.Span
 import natchez.Trace

--- a/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/package.scala
+++ b/lambda-natchez/shared/src/main/scala/feral/lambda/natchez/package.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feral.lambda
+
+import _root_.natchez.Kernel
+import feral.lambda.events.ApiGatewayProxyEvent
+import feral.lambda.events.ApiGatewayProxyEventV2
+import feral.lambda.events.DynamoDbStreamEvent
+import feral.lambda.events.KinesisStreamEvent
+import feral.lambda.events.S3BatchEvent
+import feral.lambda.events.SqsRecordAttributes
+import feral.lambda.natchez.KernelSource
+import org.typelevel.ci._
+
+protected trait KernelSources {
+  private[this] val `X-Amzn-Trace-Id` = ci"X-Amzn-Trace-Id"
+
+  implicit def apiGatewayProxyEvent: KernelSource[ApiGatewayProxyEvent] =
+    e => Kernel(e.headers.getOrElse(Map.empty))
+
+  implicit def apiGatewayProxyEventV2: KernelSource[ApiGatewayProxyEventV2] =
+    e => Kernel(e.headers)
+
+  implicit def sqsRecordAttributes: KernelSource[SqsRecordAttributes] =
+    a => Kernel(a.awsTraceHeader.map(`X-Amzn-Trace-Id` -> _).toMap)
+
+  implicit def s3BatchEvent: KernelSource[S3BatchEvent] = KernelSource.emptyKernelSource
+
+  @deprecated(
+    "See feral.lambda.events.KinesisStreamEvent deprecation",
+    since = "0.3.0"
+  )
+  implicit def kinesisStreamEvent: KernelSource[KinesisStreamEvent] =
+    KernelSource.emptyKernelSource
+
+  implicit def dynamoDbStreamEvent: KernelSource[DynamoDbStreamEvent] =
+    KernelSource.emptyKernelSource
+}
+
+package object natchez extends KernelSources

--- a/lambda-natchez/shared/src/test/scala/feral/lambda/natchez/TracedHandlerSuite.scala
+++ b/lambda-natchez/shared/src/test/scala/feral/lambda/natchez/TracedHandlerSuite.scala
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
-package feral.lambda
+package feral.lambda.natchez
 
 import cats.data.Kleisli
 import cats.effect.IO
+import feral.lambda.INothing
+import feral.lambda.Invocation
 import feral.lambda.events.KinesisStreamEvent
 import natchez.EntryPoint
 import natchez.Span

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEvent.scala
@@ -18,7 +18,6 @@ package feral.lambda
 package events
 
 import io.circe.Decoder
-import natchez.Kernel
 import org.typelevel.ci.CIString
 
 sealed abstract class ApiGatewayProxyEvent {
@@ -77,9 +76,6 @@ object ApiGatewayProxyEvent {
     "headers",
     "multiValueHeaders"
   )(ApiGatewayProxyEvent.apply)
-
-  implicit def kernelSource: KernelSource[ApiGatewayProxyEvent] =
-    e => Kernel(e.headers.getOrElse(Map.empty))
 
   private final case class Impl(
       body: Option[String],

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyEventV2.scala
@@ -18,7 +18,6 @@ package feral.lambda
 package events
 
 import io.circe.Decoder
-import natchez.Kernel
 import org.typelevel.ci.CIString
 
 sealed abstract class Http {
@@ -85,9 +84,6 @@ object ApiGatewayProxyEventV2 {
     "body",
     "isBase64Encoded"
   )(ApiGatewayProxyEventV2.apply)
-
-  implicit def kernelSource: KernelSource[ApiGatewayProxyEventV2] =
-    e => Kernel(e.headers)
 
   private final case class Impl(
       rawPath: String,

--- a/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/DynamoDbStreamEvent.scala
@@ -215,8 +215,6 @@ object DynamoDbStreamEvent {
   implicit val decoder: Decoder[DynamoDbStreamEvent] =
     Decoder.forProduct1("Records")(DynamoDbStreamEvent.apply)
 
-  implicit def kernelSource: KernelSource[DynamoDbStreamEvent] = KernelSource.emptyKernelSource
-
   private final case class Impl(
       records: List[DynamoDbRecord]
   ) extends DynamoDbStreamEvent {

--- a/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/KinesisStreamEvent.scala
@@ -146,8 +146,6 @@ object KinesisStreamEvent {
   implicit val decoder: Decoder[KinesisStreamEvent] =
     Decoder.forProduct1("Records")(KinesisStreamEvent.apply)
 
-  implicit def kernelSource: KernelSource[KinesisStreamEvent] = KernelSource.emptyKernelSource
-
   private final case class Impl(
       records: List[KinesisStreamRecord]
   ) extends KinesisStreamEvent {

--- a/lambda/shared/src/main/scala/feral/lambda/events/S3BatchEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/S3BatchEvent.scala
@@ -16,7 +16,6 @@
 
 package feral.lambda.events
 
-import feral.lambda.KernelSource
 import io.circe.Decoder
 
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/trigger/s3-batch.d.ts
@@ -40,8 +39,6 @@ object S3BatchEvent {
   implicit val decoder: Decoder[S3BatchEvent] =
     Decoder.forProduct4("invocationSchemaVersion", "invocationId", "job", "tasks")(
       S3BatchEvent.apply)
-
-  implicit def kernelSource: KernelSource[S3BatchEvent] = KernelSource.emptyKernelSource
 
   private final case class Impl(
       invocationSchemaVersion: String,

--- a/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
@@ -19,7 +19,6 @@ package events
 
 import io.circe.Decoder
 import io.circe.scodec._
-import org.typelevel.ci._
 import scodec.bits.ByteVector
 
 import java.time.Instant

--- a/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/SqsEvent.scala
@@ -19,7 +19,6 @@ package events
 
 import io.circe.Decoder
 import io.circe.scodec._
-import natchez.Kernel
 import org.typelevel.ci._
 import scodec.bits.ByteVector
 
@@ -176,9 +175,6 @@ object SqsRecordAttributes {
     )
   }
 
-  implicit def kernelSource: KernelSource[SqsRecordAttributes] = a =>
-    Kernel(a.awsTraceHeader.map(`X-Amzn-Trace-Id` -> _).toMap)
-
   private final case class Impl(
       awsTraceHeader: Option[String],
       approximateReceiveCount: String,
@@ -192,7 +188,6 @@ object SqsRecordAttributes {
     override def productPrefix = "SqsRecordAttributes"
   }
 
-  private[this] val `X-Amzn-Trace-Id` = ci"X-Amzn-Trace-Id"
 }
 
 sealed abstract class SqsMessageAttribute


### PR DESCRIPTION
This is to allow consumers the choice of natchez or otel4s, related to supporting #339 #340 

No breaking changes except requiring a `feral.lambda.natchez._` import