### PR TITLE
Fix query parameters avoiding duplicates

### DIFF
--- a/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
+++ b/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
@@ -61,11 +61,8 @@ object ApiGatewayProxyHandler {
 
   private[http4s] def decodeEvent[F[_]: Concurrent](
       event: ApiGatewayProxyEvent): F[Request[F]] = {
-    val queryString: String = List(
-      getQueryStringParameters(event.queryStringParameters),
-      getMultiValueQueryStringParameters(event.multiValueQueryStringParameters)
-    ).filter(_.nonEmpty).mkString("&")
-
+    val queryString: String = getMultiValueQueryStringParameters(
+      event.multiValueQueryStringParameters)
     val uriString: String = event.path + (if (queryString.nonEmpty) s"?$queryString" else "")
 
     for {
@@ -96,12 +93,6 @@ object ApiGatewayProxyHandler {
       body = Stream.fromOption[F](event.body).through(readBody)
     )
   }
-
-  private def getQueryStringParameters(
-      queryStringParameters: Option[Map[String, String]]): String =
-    queryStringParameters.fold("") { params =>
-      params.map { case (key, value) => s"$key=$value" }.mkString("&")
-    }
 
   private def getMultiValueQueryStringParameters(
       multiValueQueryStringParameters: Option[Map[String, List[String]]]): String =

--- a/lambda-http4s/src/test/scala/feral/lambda/http4s/ApiGatewayProxyHandlerSuite.scala
+++ b/lambda-http4s/src/test/scala/feral/lambda/http4s/ApiGatewayProxyHandlerSuite.scala
@@ -37,6 +37,8 @@ class ApiGatewayProxyHandlerSuite extends CatsEffectSuite {
     "X-Amz-Cf-Id" -> "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
     "Host" -> "1234567890.execute-api.us-east-1.amazonaws.com",
     "Accept-Encoding" -> "gzip, deflate, sdch",
+    "X-MultiHeader" -> "foo",
+    "X-MultiHeader" -> "bar",
     "X-Forwarded-Port" -> "443",
     "Cache-Control" -> "max-age=0",
     "CloudFront-Viewer-Country" -> "US",
@@ -57,7 +59,7 @@ class ApiGatewayProxyHandlerSuite extends CatsEffectSuite {
       event <- event.as[ApiGatewayProxyEvent].liftTo[IO]
       request <- ApiGatewayProxyHandler.decodeEvent[IO](event)
       _ <- IO(assertEquals(request.method, Method.POST))
-      _ <- IO(assertEquals(request.uri, uri"/path/to/resource?foo=bar"))
+      _ <- IO(assertEquals(request.uri, uri"/path/to/resource?foo=bar&foo=baz"))
       _ <- IO(assertEquals(request.headers, expectedHeaders))
       responseBody <- request.bodyText.compile.string
       _ <- IO(assertEquals(responseBody, expectedBody))

--- a/lambda-http4s/src/test/scala/feral/lambda/http4s/ApiGatewayProxyHandlerSuite.scala
+++ b/lambda-http4s/src/test/scala/feral/lambda/http4s/ApiGatewayProxyHandlerSuite.scala
@@ -57,7 +57,7 @@ class ApiGatewayProxyHandlerSuite extends CatsEffectSuite {
       event <- event.as[ApiGatewayProxyEvent].liftTo[IO]
       request <- ApiGatewayProxyHandler.decodeEvent[IO](event)
       _ <- IO(assertEquals(request.method, Method.POST))
-      _ <- IO(assertEquals(request.uri, uri"/path/to/resource?foo=bar&foo=bar"))
+      _ <- IO(assertEquals(request.uri, uri"/path/to/resource?foo=bar"))
       _ <- IO(assertEquals(request.headers, expectedHeaders))
       responseBody <- request.bodyText.compile.string
       _ <- IO(assertEquals(responseBody, expectedBody))

--- a/lambda/shared/src/test/scala/feral/lambda/events/ApiGatewayProxyEventSuite.scala
+++ b/lambda/shared/src/test/scala/feral/lambda/events/ApiGatewayProxyEventSuite.scala
@@ -43,7 +43,8 @@ object ApiGatewayProxyEventSuite {
     },
     "multiValueQueryStringParameters": {
       "foo": [
-        "bar"
+        "bar",
+        "baz"
       ]
     },
     "pathParameters": {
@@ -70,7 +71,8 @@ object ApiGatewayProxyEventSuite {
       "X-Amz-Cf-Id": "cDehVQoZnx43VYQb9j2-nvCh-9z396Uhbp027Y2JvkCPNLmGJHqlaA==",
       "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
       "X-Forwarded-Port": "443",
-      "X-Forwarded-Proto": "https"
+      "X-Forwarded-Proto": "https",
+      "X-MultiHeader": "foo"
     },
     "multiValueHeaders": {
       "Accept": [
@@ -104,7 +106,7 @@ object ApiGatewayProxyEventSuite {
         "US"
       ],
       "Host": [
-        "0123456789.execute-api.us-east-1.amazonaws.com"
+        "1234567890.execute-api.us-east-1.amazonaws.com"
       ],
       "Upgrade-Insecure-Requests": [
         "1"
@@ -126,6 +128,10 @@ object ApiGatewayProxyEventSuite {
       ],
       "X-Forwarded-Proto": [
         "https"
+      ],
+      "X-MultiHeader": [
+        "foo",
+        "bar"
       ]
     },
     "requestContext": {


### PR DESCRIPTION
queryStringParameters and multiValueQueryStringParameters were merged together, but multiValueQueryStringParameters already contains all queryStringParameters