### PR TITLE
Add headers to proxy integration

### DIFF
--- a/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
+++ b/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandler.scala
@@ -50,9 +50,11 @@ object ApiGatewayProxyHandler {
         .compile
         .string
     } yield {
+      val headers = response.headers.headers.groupMap(_.name)(_.value)
       Some(
         ApiGatewayProxyResult(
           response.status.code,
+          headers.map { case (name, values) => name -> values.mkString(",") },
           responseBody,
           isBase64Encoded
         )

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResult.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResult.scala
@@ -35,6 +35,10 @@ object ApiGatewayProxyResult {
       isBase64Encoded: Boolean): ApiGatewayProxyResult =
     new Impl(statusCode, headers, body, isBase64Encoded)
 
+  @deprecated("This constructor does not have headers", "0.3.0")
+  def apply(statusCode: Int, body: String, isBase64Encoded: Boolean): ApiGatewayProxyResult =
+    new Impl(statusCode, Map.empty[CIString, String], body, isBase64Encoded)
+
   import codecs.encodeKeyCIString
   implicit def encoder: Encoder[ApiGatewayProxyResult] = Encoder.forProduct4(
     "statusCode",

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResult.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResult.scala
@@ -17,26 +17,35 @@
 package feral.lambda.events
 
 import io.circe.Encoder
+import org.typelevel.ci.CIString
 
 sealed abstract class ApiGatewayProxyResult {
   def statusCode: Int
+  def headers: Map[CIString, String]
   def body: String
   def isBase64Encoded: Boolean
 }
 
 object ApiGatewayProxyResult {
 
-  def apply(statusCode: Int, body: String, isBase64Encoded: Boolean): ApiGatewayProxyResult =
-    new Impl(statusCode, body, isBase64Encoded)
+  def apply(
+      statusCode: Int,
+      headers: Map[CIString, String],
+      body: String,
+      isBase64Encoded: Boolean): ApiGatewayProxyResult =
+    new Impl(statusCode, headers, body, isBase64Encoded)
 
-  implicit def encoder: Encoder[ApiGatewayProxyResult] = Encoder.forProduct3(
+  import codecs.encodeKeyCIString
+  implicit def encoder: Encoder[ApiGatewayProxyResult] = Encoder.forProduct4(
     "statusCode",
+    "headers",
     "body",
     "isBase64Encoded"
-  )(r => (r.statusCode, r.body, r.isBase64Encoded))
+  )(r => (r.statusCode, r.headers, r.body, r.isBase64Encoded))
 
   private final case class Impl(
       statusCode: Int,
+      headers: Map[CIString, String],
       body: String,
       isBase64Encoded: Boolean
   ) extends ApiGatewayProxyResult {

--- a/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResult.scala
+++ b/lambda/shared/src/main/scala/feral/lambda/events/ApiGatewayProxyResult.scala
@@ -35,9 +35,9 @@ object ApiGatewayProxyResult {
       isBase64Encoded: Boolean): ApiGatewayProxyResult =
     new Impl(statusCode, headers, body, isBase64Encoded)
 
-  @deprecated("This constructor does not have headers", "0.3.0")
+  @deprecated("Use apply method which takes headers", "0.3.0")
   def apply(statusCode: Int, body: String, isBase64Encoded: Boolean): ApiGatewayProxyResult =
-    new Impl(statusCode, Map.empty[CIString, String], body, isBase64Encoded)
+    apply(statusCode, Map.empty, body, isBase64Encoded)
 
   import codecs.encodeKeyCIString
   implicit def encoder: Encoder[ApiGatewayProxyResult] = Encoder.forProduct4(


### PR DESCRIPTION
I had trouble rendering a page because content-type is not correctly passed to API gateway when using REST API.
This problem is not present when using HTTP integration and I noticed that _headers_ is missing.
[Documentation on integration response](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-integration-settings-integration-response.html).

I used the same implentation as [ApiGatewayProxyStructuredResultV2](https://github.com/typelevel/feral/blob/main/lambda-http4s/src/main/scala/feral/lambda/http4s/ApiGatewayProxyHandlerV2.scala#L58).