### PR TITLE
Feral for AzureFunctions

### DIFF
--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureFunctionHttpPlatform.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureFunctionHttpPlatform.scala
@@ -1,5 +1,0 @@
-package feral.functions
-
-object IOAzureFunctionHttpPlatform {
-  
-}

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureFunctionHttpPlatform.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureFunctionHttpPlatform.scala
@@ -1,0 +1,5 @@
+package feral.functions
+
+object IOAzureFunctionHttpPlatform {
+  
+}

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -32,9 +32,10 @@ import cats.effect.Resource
 import cats.syntax.all._
 import cats.effect.unsafe.IORuntime
 import cats.effect.std.Dispatcher
+import feral.functions.facade.Context
 
 abstract class IOAzureHttpFunction {
-  protected def handler: InvocationContext => Resource[IO, HttpApp[IO]]
+  protected def handler: Context => Resource[IO, HttpApp[IO]]
   protected def appConfig: AppConfig = buildDefaultConfig(handlerFn)
   protected def qBound: Int = 100
 
@@ -62,7 +63,7 @@ abstract class IOAzureHttpFunction {
         case (dispatcher, handle) => {
           val io = for {
             request <- Parser.decodeRequest[IO](requestJS)
-            response <- handle(context).use(app => app.run(request))
+            response <- handle(Context(context)).use(app => app.run(request))
             respEncoded <- Parser.encodeResponse[IO](response, dispatcher, qBound)
           } yield respEncoded
 

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -15,6 +15,8 @@ import org.http4s.Request
 import feral.functions.facade.JSRequest
 import feral.functions.facade.JSHeaders
 import cats.effect.std.Dispatcher
+import feral.functions.util.Parser
+import fs2.text.utf8
 
 abstract class IOAzureHttpFunction {
   protected def handler: InvocationContext => Resource[IO, HttpApp[IO]]
@@ -24,7 +26,8 @@ abstract class IOAzureHttpFunction {
   final def main(args: Array[String]): Unit =
     IOAzureHttpFunction.App.http(functionName, appConfig)
 
-  private val functionName: String = getClass.getSimpleName.init //may want to add timestamp for testing
+  private val functionName: String =
+    getClass.getSimpleName.init // may want to add timestamp for testing
 
   private val appConfig = js
     .Dynamic
@@ -36,32 +39,49 @@ abstract class IOAzureHttpFunction {
     )
 
   private lazy val handlerFn
-    : js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
+      : js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
     val dispatcherHandle = {
       Dispatcher
         .parallel[IO](await = true)
         .product(Resource.pure(handler))
         .allocated
-        .map(_._1) //drop unused finalizer, this resource will live for the duration
+        .map(_._1) // drop unused finalizer, this resource will live for the duration
         .unsafeToPromise()(runtime)
     }
 
-    (request, context) => {
-      //do dispatcher thing
+    (requestJS, context) => {
+      // do dispatcher thing
+      context.log("befor FOR COMP")
+      dispatcherHandle.`then`[js.Any] {
+        case (dispatcher, handle) => {
+          val io = for {
+            _ <- IO(context.log("FOR COMP"))
+            request <- Parser.decodeRequest[IO](requestJS)
+            _ <- IO(context.log(request.uri.toString()))
+            response <- handle(context).use(app => app.run(request))
+            _ <- IO(context.log(response.status.toString()))
+            bodyList <- response.body.through(utf8.decode).compile.toList
+            _ <- IO(context.log(bodyList.toString()))
+            respEncoded <- Parser.encodeResponse[IO](response)
+            _ <- IO(context.log("Decoded")) 
+            _ <- IO(context.log(respEncoded.toString()))
+          } yield respEncoded 
+          
+          dispatcher.unsafeToPromise(io)
+        }
+      }
       /////
-      val h = request.headers
-      val headers = JSHeaders.keyList(h)
-      context.log(s"final pipeline! last try for now")
+      // impure!!!
 
-      val response =
-        js.Dynamic
-          .literal(
-            status = 200,
-            body = "payload",
-            headers = js.Dynamic.literal("content-type" -> "text/plain")
-          )
+      // val response =
+      //   js.Dynamic
+      //     .literal(
+      //       status = 200,
+      //       body = "payload",
+      //       headers = js.Dynamic.literal("content-type" -> "text/plain")
+      //     )
 
-      js.Promise.resolve[js.UndefOr[js.Any]](response)
+      // js.Promise.resolve[js.UndefOr[js.Any]](response)
     }
   }
 }

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -35,7 +35,7 @@ abstract class IOAzureHttpFunction {
     (request, context) => {
       val h = request.headers
       val headers = JSHeaders.keyList(h)
-      context.log(s"headers: $headers")
+      context.log(s"final pipeline! last try for now")
 
       val response =
         js.Dynamic

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -56,7 +56,7 @@ abstract class IOAzureHttpFunction {
           val io = for {
             request <- Parser.decodeRequest[IO](requestJS)
             response <- handle(context).use(app => app.run(request))
-            respEncoded <- Parser.encodeResponseV2[IO](response, dispatcher, qBound)
+            respEncoded <- Parser.encodeResponse[IO](response, dispatcher, qBound)
           } yield respEncoded
 
           dispatcher.unsafeToPromise(io)

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -3,20 +3,19 @@ package feral.functions
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import feral.functions.facade.InvocationContext
-//import scala.scalajs.js.JSConverters._
 
-@js.native
-@JSImport("@azure/functions", "app")
-object App extends js.Object {
-  def http(
-      name: String,
-      appConfig: js.Object
-  ): Unit = js.native
-}
+import org.http4s.HttpApp
+//import cats.effect.IO
+
+//import scala.scalajs.js.JSConverters._
+// import org.http4s.nodejs.IncomingMessage
+// import org.http4s.nodejs.ServerResponse
 
 abstract class IOAzureHttpFunction {
+  //val appFromIC: InvocationContext => HttpApp[IO]
+
   final def main(args: Array[String]): Unit =
-    App.http(functionName, appConfig)
+    IOAzureHttpFunction.App.http(functionName, appConfig)
 
   protected val functionName: String = getClass.getSimpleName.init
 
@@ -47,4 +46,13 @@ abstract class IOAzureHttpFunction {
   }
 }
 
-object IOAzureHttpFunction {}
+object IOAzureHttpFunction {
+  @js.native
+  @JSImport("@azure/functions", "app")
+  object App extends js.Object {
+    def http(
+        name: String,
+        appConfig: js.Object
+    ): Unit = js.native
+  }
+}

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -58,14 +58,14 @@ abstract class IOAzureHttpFunction {
             _ <- IO(context.log("FOR COMP"))
             request <- Parser.decodeRequest[IO](requestJS)
             _ <- IO(context.log(request.uri.toString()))
-            bodyList <- request.body.through(utf8.decode).compile.toList
-            _ <- IO(context.log("req body: " + bodyList.toString()))
+            //bodyList <- request.body.through(utf8.decode).compile.toList
+            //_ <- IO(context.log("req body: " + bodyList.toString()))
             
             response <- handle(context).use(app => app.run(request))
             _ <- IO(context.log(response.status.toString()))
-            bodyList <- response.body.through(utf8.decode).compile.toList
-            _ <- IO(context.log("resp body: " + bodyList.toString()))
-            respEncoded <- Parser.encodeResponse[IO](response)
+            //bodyList <- response.body.through(utf8.decode).compile.toList
+            //_ <- IO(context.log("resp body: " + bodyList.toString()))
+            respEncoded <- Parser.encodeResponse[IO](response, dispatcher)
             _ <- IO(context.log("Decoded")) 
             _ <- IO(context.log(respEncoded.toString()))
           } yield respEncoded 

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -20,6 +20,7 @@ import feral.functions.util.Parser
 
 abstract class IOAzureHttpFunction {
   protected def handler: InvocationContext => Resource[IO, HttpApp[IO]]
+  protected def qBound: Int = 100
 
   private val runtime = IORuntime.global
 
@@ -55,7 +56,7 @@ abstract class IOAzureHttpFunction {
           val io = for {
             request <- Parser.decodeRequest[IO](requestJS)
             response <- handle(context).use(app => app.run(request))
-            respEncoded <- Parser.encodeResponse[IO](response, dispatcher)
+            respEncoded <- Parser.encodeResponseV2[IO](response, dispatcher, qBound)
           } yield respEncoded
 
           dispatcher.unsafeToPromise(io)

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -11,12 +11,12 @@ import cats.syntax.all._
 import cats.effect.unsafe.IORuntime
 
 //import scala.scalajs.js.JSConverters._
-import org.http4s.Request
+//import org.http4s.Request
 import feral.functions.facade.JSRequest
-import feral.functions.facade.JSHeaders
+//import feral.functions.facade.JSHeaders
 import cats.effect.std.Dispatcher
 import feral.functions.util.Parser
-import fs2.text.utf8
+//import fs2.text.utf8
 
 abstract class IOAzureHttpFunction {
   protected def handler: InvocationContext => Resource[IO, HttpApp[IO]]
@@ -27,7 +27,7 @@ abstract class IOAzureHttpFunction {
     IOAzureHttpFunction.App.http(functionName, appConfig)
 
   private val functionName: String =
-    getClass.getSimpleName.init // may want to add timestamp for testing
+    getClass.getSimpleName.init
 
   private val appConfig = js
     .Dynamic
@@ -50,41 +50,17 @@ abstract class IOAzureHttpFunction {
     }
 
     (requestJS, context) => {
-      // do dispatcher thing
-      //context.log("befor FOR COMP")
       dispatcherHandle.`then`[js.Any] {
         case (dispatcher, handle) => {
           val io = for {
-            _ <- IO(context.log("FOR COMP"))
             request <- Parser.decodeRequest[IO](requestJS)
-            _ <- IO(context.log(request.uri.toString()))
-            //bodyList <- request.body.through(utf8.decode).compile.toList
-            //_ <- IO(context.log("req body: " + bodyList.toString()))
-            
             response <- handle(context).use(app => app.run(request))
-            _ <- IO(context.log(response.status.toString()))
-            //bodyList <- response.body.through(utf8.decode).compile.toList
-            //_ <- IO(context.log("resp body: " + bodyList.toString()))
             respEncoded <- Parser.encodeResponse[IO](response, dispatcher)
-            _ <- IO(context.log("Decoded")) 
-            _ <- IO(context.log(respEncoded.toString()))
-          } yield respEncoded 
-          
+          } yield respEncoded
+
           dispatcher.unsafeToPromise(io)
         }
       }
-      /////
-      // impure!!!
-
-      // val response =
-      //   js.Dynamic
-      //     .literal(
-      //       status = 200,
-      //       body = "payload",
-      //       headers = js.Dynamic.literal("content-type" -> "text/plain")
-      //     )
-
-      // js.Promise.resolve[js.UndefOr[js.Any]](response)
     }
   }
 }

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -1,0 +1,35 @@
+package feral.functions
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+//import scala.scalajs.js.JSConverters._
+
+object IOAzureHttpFunction {
+  //case class AppObj(methods: js.Array[String], )
+}
+
+@js.native
+@JSImport("@azure/functions", "app")
+object App extends js.Object {
+  def http(
+      name: String,
+      appConfig: js.Object
+      //handler: js.Function2[js.Any, js.Any, js.Promise[js.UndefOr[js.Any]]]): Unit = js.native
+  ): Unit = js.native
+}
+
+abstract class IOAzureHttpFunction {
+  final def main(args: Array[String]): Unit =
+    App.http("functionName", appConfig)
+
+  private lazy val handlerFn: js.Function2[js.Any, js.Any, js.Promise[js.UndefOr[js.Any]]] = {
+    (request, context) => js.Promise.resolve[js.Any](request)
+  }
+
+  private val appConfig = js.Dynamic.literal(
+    methods = js.Array("GET", "PUT"),
+    authLevel = "anonymous",
+    route = "{*path}",
+    handler = handlerFn
+  )
+}

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -5,14 +5,13 @@ import scala.scalajs.js.annotation._
 import feral.functions.facade.InvocationContext
 
 import org.http4s.HttpApp
-//import cats.effect.IO
+import cats.effect.IO
+import cats.effect.Resource
 
 //import scala.scalajs.js.JSConverters._
-// import org.http4s.nodejs.IncomingMessage
-// import org.http4s.nodejs.ServerResponse
 
 abstract class IOAzureHttpFunction {
-  //val appFromIC: InvocationContext => HttpApp[IO]
+  def buildHttpApp(context: InvocationContext): Resource[IO, HttpApp[IO]]
 
   final def main(args: Array[String]): Unit =
     IOAzureHttpFunction.App.http(functionName, appConfig)

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -4,27 +4,20 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation._
 //import scala.scalajs.js.JSConverters._
 
-object IOAzureHttpFunction {
-  //case class AppObj(methods: js.Array[String], )
-}
-
 @js.native
 @JSImport("@azure/functions", "app")
 object App extends js.Object {
   def http(
       name: String,
       appConfig: js.Object
-      //handler: js.Function2[js.Any, js.Any, js.Promise[js.UndefOr[js.Any]]]): Unit = js.native
   ): Unit = js.native
 }
 
 abstract class IOAzureHttpFunction {
   final def main(args: Array[String]): Unit =
-    App.http("functionName", appConfig)
+    App.http(functionName, appConfig)
 
-  private lazy val handlerFn: js.Function2[js.Any, js.Any, js.Promise[js.UndefOr[js.Any]]] = {
-    (request, context) => js.Promise.resolve[js.Any](request)
-  }
+  protected val functionName: String = getClass.getSimpleName.init
 
   private val appConfig = js.Dynamic.literal(
     methods = js.Array("GET", "PUT"),
@@ -32,4 +25,12 @@ abstract class IOAzureHttpFunction {
     route = "{*path}",
     handler = handlerFn
   )
+
+  private lazy val handlerFn: js.Function2[js.Any, js.Any, js.Promise[js.UndefOr[js.Any]]] = {
+    (request, context) => js.Promise.resolve[js.Any](context)
+  }
+}
+
+object IOAzureHttpFunction {
+  //case class AppObj(methods: js.Array[String], )
 }

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -7,19 +7,24 @@ import feral.functions.facade.InvocationContext
 import org.http4s.HttpApp
 import cats.effect.IO
 import cats.effect.Resource
+import cats.syntax.all._
+import cats.effect.unsafe.IORuntime
 
 //import scala.scalajs.js.JSConverters._
 import org.http4s.Request
 import feral.functions.facade.JSRequest
 import feral.functions.facade.JSHeaders
+import cats.effect.std.Dispatcher
 
 abstract class IOAzureHttpFunction {
-  def buildHttpApp(context: InvocationContext): Resource[IO, HttpApp[IO]]
+  protected def handler: InvocationContext => Resource[IO, HttpApp[IO]]
+
+  private val runtime = IORuntime.global
 
   final def main(args: Array[String]): Unit =
     IOAzureHttpFunction.App.http(functionName, appConfig)
 
-  protected val functionName: String = getClass.getSimpleName.init //may want to add timestamp for testing
+  private val functionName: String = getClass.getSimpleName.init //may want to add timestamp for testing
 
   private val appConfig = js
     .Dynamic
@@ -31,8 +36,19 @@ abstract class IOAzureHttpFunction {
     )
 
   private lazy val handlerFn
-      : js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
+    : js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
+    val dispatcherHandle = {
+      Dispatcher
+        .parallel[IO](await = true)
+        .product(Resource.pure(handler))
+        .allocated
+        .map(_._1) //drop unused finalizer, this resource will live for the duration
+        .unsafeToPromise()(runtime)
+    }
+
     (request, context) => {
+      //do dispatcher thing
+      /////
       val h = request.headers
       val headers = JSHeaders.keyList(h)
       context.log(s"final pipeline! last try for now")

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -2,6 +2,7 @@ package feral.functions
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
+import feral.functions.facade.InvocationContext
 //import scala.scalajs.js.JSConverters._
 
 @js.native
@@ -19,18 +20,31 @@ abstract class IOAzureHttpFunction {
 
   protected val functionName: String = getClass.getSimpleName.init
 
-  private val appConfig = js.Dynamic.literal(
-    methods = js.Array("GET", "PUT"),
-    authLevel = "anonymous",
-    route = "{*path}",
-    handler = handlerFn
-  )
+  private val appConfig = js
+    .Dynamic
+    .literal(
+      methods = js.Array("GET", "PUT"),
+      authLevel = "anonymous",
+      route = "{*path}",
+      handler = handlerFn
+    )
 
-  private lazy val handlerFn: js.Function2[js.Any, js.Any, js.Promise[js.UndefOr[js.Any]]] = {
-    (request, context) => js.Promise.resolve[js.Any](context)
+  private lazy val handlerFn
+      : js.Function2[js.Any, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
+    (request, context) => {
+      context.log("this is a log msg!!!")
+
+      val response =
+        js.Dynamic
+          .literal(
+            status = 200,
+            body = "payload",
+            headers = js.Dynamic.literal("content-type" -> "text/plain")
+          )
+
+      js.Promise.resolve[js.UndefOr[js.Any]](response)
+    }
   }
 }
 
-object IOAzureHttpFunction {
-  //case class AppObj(methods: js.Array[String], )
-}
+object IOAzureHttpFunction {}

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -1,35 +1,52 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.functions
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
+
 import feral.functions.facade.InvocationContext
+import feral.functions.facade.JSRequest
+import feral.functions.util.AppConfig.buildDefaultConfig
+import feral.functions.util.AppConfig
+import feral.functions.util.Parser
 
 import org.http4s.HttpApp
+
 import cats.effect.IO
 import cats.effect.Resource
 import cats.syntax.all._
 import cats.effect.unsafe.IORuntime
-
-
-import feral.functions.facade.JSRequest
 import cats.effect.std.Dispatcher
-import feral.functions.util.Parser
-import feral.functions.util.AppConfig.buildDefaultConfig
 
 abstract class IOAzureHttpFunction {
   protected def handler: InvocationContext => Resource[IO, HttpApp[IO]]
-  protected def appConfig = buildDefaultConfig(handlerFn).toJS
+  protected def appConfig: AppConfig = buildDefaultConfig(handlerFn)
   protected def qBound: Int = 100
 
-  private val runtime = IORuntime.global
+  private[functions] val runtime = IORuntime.global
 
   final def main(args: Array[String]): Unit =
-    IOAzureHttpFunction.App.http(functionName, appConfig)
+    IOAzureHttpFunction.App.http(functionName, appConfig.toJS)
 
-  private val functionName: String =
+  private[functions] val functionName: String =
     getClass.getSimpleName.init
 
-  private lazy val handlerFn
+  private[functions] lazy val handlerFn
       : js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
     val dispatcherHandle = {
       Dispatcher

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -51,17 +51,20 @@ abstract class IOAzureHttpFunction {
 
     (requestJS, context) => {
       // do dispatcher thing
-      context.log("befor FOR COMP")
+      //context.log("befor FOR COMP")
       dispatcherHandle.`then`[js.Any] {
         case (dispatcher, handle) => {
           val io = for {
             _ <- IO(context.log("FOR COMP"))
             request <- Parser.decodeRequest[IO](requestJS)
             _ <- IO(context.log(request.uri.toString()))
+            bodyList <- request.body.through(utf8.decode).compile.toList
+            _ <- IO(context.log("req body: " + bodyList.toString()))
+            
             response <- handle(context).use(app => app.run(request))
             _ <- IO(context.log(response.status.toString()))
             bodyList <- response.body.through(utf8.decode).compile.toList
-            _ <- IO(context.log(bodyList.toString()))
+            _ <- IO(context.log("resp body: " + bodyList.toString()))
             respEncoded <- Parser.encodeResponse[IO](response)
             _ <- IO(context.log("Decoded")) 
             _ <- IO(context.log(respEncoded.toString()))

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -9,6 +9,9 @@ import cats.effect.IO
 import cats.effect.Resource
 
 //import scala.scalajs.js.JSConverters._
+import org.http4s.Request
+import feral.functions.facade.JSRequest
+import feral.functions.facade.JSHeaders
 
 abstract class IOAzureHttpFunction {
   def buildHttpApp(context: InvocationContext): Resource[IO, HttpApp[IO]]
@@ -16,7 +19,7 @@ abstract class IOAzureHttpFunction {
   final def main(args: Array[String]): Unit =
     IOAzureHttpFunction.App.http(functionName, appConfig)
 
-  protected val functionName: String = getClass.getSimpleName.init
+  protected val functionName: String = getClass.getSimpleName.init //may want to add timestamp for testing
 
   private val appConfig = js
     .Dynamic
@@ -28,9 +31,11 @@ abstract class IOAzureHttpFunction {
     )
 
   private lazy val handlerFn
-      : js.Function2[js.Any, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
+      : js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {
     (request, context) => {
-      context.log("this is a log msg!!!")
+      val h = request.headers
+      val headers = JSHeaders.keyList(h)
+      context.log(s"headers: $headers")
 
       val response =
         js.Dynamic

--- a/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/IOAzureHttpFunction.scala
@@ -10,16 +10,15 @@ import cats.effect.Resource
 import cats.syntax.all._
 import cats.effect.unsafe.IORuntime
 
-//import scala.scalajs.js.JSConverters._
-//import org.http4s.Request
+
 import feral.functions.facade.JSRequest
-//import feral.functions.facade.JSHeaders
 import cats.effect.std.Dispatcher
 import feral.functions.util.Parser
-//import fs2.text.utf8
+import feral.functions.util.AppConfig.buildDefaultConfig
 
 abstract class IOAzureHttpFunction {
   protected def handler: InvocationContext => Resource[IO, HttpApp[IO]]
+  protected def appConfig = buildDefaultConfig(handlerFn).toJS
   protected def qBound: Int = 100
 
   private val runtime = IORuntime.global
@@ -29,15 +28,6 @@ abstract class IOAzureHttpFunction {
 
   private val functionName: String =
     getClass.getSimpleName.init
-
-  private val appConfig = js
-    .Dynamic
-    .literal(
-      methods = js.Array("GET", "PUT"),
-      authLevel = "anonymous",
-      route = "{*path}",
-      handler = handlerFn
-    )
 
   private lazy val handlerFn
       : js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]] = {

--- a/azure-functions/js/src/main/scala/feral/functions/facade/Context.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/Context.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package feral.functions.facade
+
+final case class Context(context: InvocationContext) {
+  def log(m: String): Unit = context.log(m)
+  def trace(m: String): Unit = context.trace(m)
+  def debug(m: String): Unit = context.debug(m)
+  def info(m: String): Unit = context.info(m)
+  def warn(m: String): Unit = context.warn(m)
+  def error(m: String): Unit = context.error(m)
+}

--- a/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
@@ -10,21 +10,49 @@ trait InvocationContext extends js.Object {
   def info(args: js.Any*): Unit = js.native
   def warn(args: js.Any*): Unit = js.native
   def error(args: js.Any*): Unit = js.native
+
+  def functionId: String = js.native
+  def functionName: String = js.native
+  def extraInputs: ExtraInputs = js.native
+  def extraOutputs: ExtraOutputs = js.native
+  def retryContext: js.UndefOr[RetryContext] = js.native
+  def traceContext: js.UndefOr[TraceContext] = js.native
+  def options: Options = js.native
+}
+
+@js.native
+trait ExtraInputs extends js.Object {
+  def get(binding: js.Any): js.Any = js.native
+}
+
+@js.native
+trait ExtraOutputs extends js.Object {
+  def set(binding: js.Any, value: js.Any): Unit = js.native
+}
+
+@js.native
+trait RetryContext extends js.Object {
+  def retryCount: Int = js.native
+  def maxRetryCount: Int = js.native
+  def exception: js.UndefOr[js.Any] = js.native
+}
+
+@js.native
+trait TraceContext extends js.Object {
+  def traceParent: js.UndefOr[String] = js.native
+  def traceState: js.UndefOr[String] = js.native
+  def attributes: js.UndefOr[js.Dictionary[js.Any]] = js.native
+}
+
+@js.native
+trait Options extends js.Object {
+  def trigger: js.UndefOr[js.Any] = js.native
+  def extraInputs: js.UndefOr[js.Array[js.Any]] = js.native
+  def extraOutputs: js.UndefOr[js.Array[js.Any]] = js.native
+  def `return`: js.UndefOr[js.Any] = js.native
 }
 
 /* 
-invocationId: string;
-    functionName: string;
-    extraInputs: InvocationContextExtraInputs;
-    extraOutputs: InvocationContextExtraOutputs;
-    log(...args: any[]): void;
-    trace(...args: any[]): void;
-    debug(...args: any[]): void;
-    info(...args: any[]): void;
-    warn(...args: any[]): void;
-    error(...args: any[]): void;
-    retryContext?: RetryContext;
-    traceContext?: TraceContext;
-    triggerMetadata?: TriggerMetadata;
-    options: EffectiveFunctionOptions;
+https://docs.azure.cn/en-us/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#invocation-context
+
  */

--- a/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
@@ -1,0 +1,30 @@
+package feral.functions.facade
+
+import scala.scalajs.js
+
+@js.native
+trait InvocationContext extends js.Object {
+  def log(args: js.Any*): Unit = js.native
+  def trace(args: js.Any*): Unit = js.native
+  def debug(args: js.Any*): Unit = js.native
+  def info(args: js.Any*): Unit = js.native
+  def warn(args: js.Any*): Unit = js.native
+  def error(args: js.Any*): Unit = js.native
+}
+
+/* 
+invocationId: string;
+    functionName: string;
+    extraInputs: InvocationContextExtraInputs;
+    extraOutputs: InvocationContextExtraOutputs;
+    log(...args: any[]): void;
+    trace(...args: any[]): void;
+    debug(...args: any[]): void;
+    info(...args: any[]): void;
+    warn(...args: any[]): void;
+    error(...args: any[]): void;
+    retryContext?: RetryContext;
+    traceContext?: TraceContext;
+    triggerMetadata?: TriggerMetadata;
+    options: EffectiveFunctionOptions;
+ */

--- a/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
@@ -54,5 +54,4 @@ trait Options extends js.Object {
 
 /* 
 https://docs.azure.cn/en-us/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#invocation-context
-
  */

--- a/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
@@ -19,7 +19,7 @@ package feral.functions.facade
 import scala.scalajs.js
 
 @js.native
-trait InvocationContext extends js.Object {
+private[functions] trait InvocationContext extends js.Object {
   def log(args: js.Any*): Unit = js.native
   def trace(args: js.Any*): Unit = js.native
   def debug(args: js.Any*): Unit = js.native
@@ -37,31 +37,31 @@ trait InvocationContext extends js.Object {
 }
 
 @js.native
-trait ExtraInputs extends js.Object {
+private[functions] trait ExtraInputs extends js.Object {
   def get(binding: js.Any): js.Any = js.native
 }
 
 @js.native
-trait ExtraOutputs extends js.Object {
+private[functions] trait ExtraOutputs extends js.Object {
   def set(binding: js.Any, value: js.Any): Unit = js.native
 }
 
 @js.native
-trait RetryContext extends js.Object {
+private[functions] trait RetryContext extends js.Object {
   def retryCount: Int = js.native
   def maxRetryCount: Int = js.native
   def exception: js.UndefOr[js.Any] = js.native
 }
 
 @js.native
-trait TraceContext extends js.Object {
+private[functions] trait TraceContext extends js.Object {
   def traceParent: js.UndefOr[String] = js.native
   def traceState: js.UndefOr[String] = js.native
   def attributes: js.UndefOr[js.Dictionary[js.Any]] = js.native
 }
 
 @js.native
-trait Options extends js.Object {
+private[functions] trait Options extends js.Object {
   def trigger: js.UndefOr[js.Any] = js.native
   def extraInputs: js.UndefOr[js.Array[js.Any]] = js.native
   def extraOutputs: js.UndefOr[js.Array[js.Any]] = js.native

--- a/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/InvocationContext.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.functions.facade
 
 import scala.scalajs.js
@@ -51,7 +67,3 @@ trait Options extends js.Object {
   def extraOutputs: js.UndefOr[js.Array[js.Any]] = js.native
   def `return`: js.UndefOr[js.Any] = js.native
 }
-
-/* 
-https://docs.azure.cn/en-us/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#invocation-context
- */

--- a/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
@@ -1,6 +1,14 @@
 package feral.functions.facade
 
 import scala.scalajs.js
+import scala.scalajs.js.typedarray.Uint8Array
+
+import fs2.Stream
+import fs2.Chunk
+
+//import cats.effect.IO
+import cats.effect.kernel.Async
+import cats.syntax.all._
 
 //may want to change to requestFacade.., think it over
 
@@ -9,7 +17,7 @@ trait JSRequest extends js.Object {
   def method: String = js.native
   def url: String = js.native
   def headers: JSHeaders = js.native
-  def body: JSReadableStream = js.native
+  def body: js.UndefOr[JSReadableStream] = js.native
 }
 
 @js.native
@@ -19,7 +27,22 @@ trait JSHeaders extends js.Object {
 }
 
 @js.native
-trait JSReadableStream extends js.Object
+trait JSReadableStream extends js.Object {
+  def getReader(): JSReadableStreamDefaultReader = js.native
+}
+
+@js.native
+trait JSReadableStreamDefaultReader extends js.Object {
+  def read(): js.Promise[JSReadObject] = js.native
+  def releaseLock(): Unit = js.native
+  def cancel(reason: js.UndefOr[js.Any]): js.Promise[Unit]
+}
+
+@js.native
+trait JSReadObject extends js.Object {
+  def value: js.UndefOr[Uint8Array] = js.native
+  def done: Boolean = js.native
+}
 
 object JSHeaders {
   def keyList(h: JSHeaders): List[String] = {
@@ -38,6 +61,54 @@ object JSHeaders {
   object Syntax {
     //syntax for method like calls???
   }
+}
+
+object JSReadableStream {
+  def toFs2[F[_]: Async](streamOption: js.UndefOr[JSReadableStream]): Stream[F, Byte] = {
+    streamOption.toOption match {
+      case None => Stream.empty
+      case Some(null) => Stream.empty
+      case Some(stream) => {
+        Stream.eval(Async[F].delay(stream.getReader())).flatMap{ reader => 
+          def nextChunk = {
+            Async[F].fromPromise(Async[F].delay(reader.read())).map{ read => 
+              if(read.done) {
+                None
+              } else {
+                val chunk = read.value
+                  .toOption
+                  .map(arr => Chunk.array[Byte](toByteArray(arr)))
+                  .getOrElse(Chunk.empty[Byte])
+                  
+                Some(chunk)
+              }
+            }
+          }
+
+          Stream
+            .repeatEval(nextChunk)
+            .unNoneTerminate
+            .flatMap(Stream.chunk)
+            .onFinalize(Async[F].delay(reader.releaseLock()))
+        }
+      }
+    }
+  }
+
+  private def toByteArray(array: Uint8Array): Array[Byte] = { 
+    val builder = Array.newBuilder[Byte]
+    val length = array.length
+    var index = 0
+
+    while(index != length) {
+      builder.addOne(array(index).toByte)
+      index = index + 1
+    }
+
+    builder.result()
+  }
+
+  object Syntax {}
 }
 
 /* Parameters

--- a/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
@@ -1,0 +1,46 @@
+package feral.functions.facade
+
+import scala.scalajs.js
+
+import scala.collection.mutable.ListBuffer
+
+@js.native
+trait JSRequest extends js.Object {
+  def method: String = js.native
+  def url: String = js.native
+  def headers: JSHeaders = js.native
+}
+
+@js.native
+trait JSHeaders extends js.Object {
+  def get(name: String): js.UndefOr[String] = js.native
+  def keys(): js.Iterator[String] = js.native 
+}
+
+object JSHeaders {
+  def keyList(h: JSHeaders): List[String] = {
+    val acc = ListBuffer[String]()
+    val itr = h.keys()
+    var entity = itr.next()
+
+    while(!entity.done) {
+      acc.addOne(entity.value)
+      entity = itr.next()
+    }
+
+    acc.result()
+  }
+
+  object Syntax {
+    //syntax for method like calls???
+  }
+}
+
+/* Parameters
+
+method: Method.GET, Method.POST, etc.
+uri: representation of the request URI
+httpVersion: the HTTP version
+headers: collection of Headers
+body: fs2.Stream[F, Byte] defining the body of the request
+attributes: Immutable Map used for carrying additional information in a type safe fashion */

--- a/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.functions.facade
 
 import scala.scalajs.js
@@ -10,7 +26,7 @@ import cats.effect.kernel.Async
 import cats.syntax.all._
 
 @js.native
-trait JSRequest extends js.Object {
+private[functions] trait JSRequest extends js.Object {
   def method: String = js.native
   def url: String = js.native
   def headers: JSHeaders = js.native
@@ -18,31 +34,31 @@ trait JSRequest extends js.Object {
 }
 
 @js.native
-trait JSHeaders extends js.Object {
+private[functions] trait JSHeaders extends js.Object {
   def get(name: String): js.UndefOr[String] = js.native
   def keys(): js.Iterator[String] = js.native 
 }
 
 @js.native
-trait JSReadableStream extends js.Object {
+private[functions] trait JSReadableStream extends js.Object {
   def getReader(): JSReadableStreamDefaultReader = js.native
 }
 
 @js.native
-trait JSReadableStreamDefaultReader extends js.Object {
+private[functions] trait JSReadableStreamDefaultReader extends js.Object {
   def read(): js.Promise[JSReadObject] = js.native
   def releaseLock(): Unit = js.native
   def cancel(reason: js.UndefOr[js.Any]): js.Promise[Unit]
 }
 
 @js.native
-trait JSReadObject extends js.Object {
+private[functions] trait JSReadObject extends js.Object {
   def value: js.UndefOr[Uint8Array] = js.native
   def done: Boolean = js.native
 }
 
 object JSHeaders {
-  def keyList(h: JSHeaders): List[String] = {
+  private[functions] def keyList(h: JSHeaders): List[String] = {
     val builder = List.newBuilder[String]
     val itr = h.keys()
     var entity = itr.next()
@@ -61,7 +77,7 @@ object JSHeaders {
 }
 
 object JSReadableStream {
-  def toFs2[F[_]: Async](streamOption: js.UndefOr[JSReadableStream]): Stream[F, Byte] = {
+  private[functions] def toFs2[F[_]: Async](streamOption: js.UndefOr[JSReadableStream]): Stream[F, Byte] = {
     streamOption.toOption match {
       case None => Stream.empty
       case Some(null) => Stream.empty

--- a/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
@@ -2,13 +2,14 @@ package feral.functions.facade
 
 import scala.scalajs.js
 
-import scala.collection.mutable.ListBuffer
+//may want to change to requestFacade.., think it over
 
 @js.native
 trait JSRequest extends js.Object {
   def method: String = js.native
   def url: String = js.native
   def headers: JSHeaders = js.native
+  def body: JSReadableStream = js.native
 }
 
 @js.native
@@ -17,18 +18,21 @@ trait JSHeaders extends js.Object {
   def keys(): js.Iterator[String] = js.native 
 }
 
+@js.native
+trait JSReadableStream extends js.Object
+
 object JSHeaders {
   def keyList(h: JSHeaders): List[String] = {
-    val acc = ListBuffer[String]()
+    val builder = List.newBuilder[String]
     val itr = h.keys()
     var entity = itr.next()
 
     while(!entity.done) {
-      acc.addOne(entity.value)
+      builder.addOne(entity.value)
       entity = itr.next()
     }
 
-    acc.result()
+    builder.result()
   }
 
   object Syntax {
@@ -40,7 +44,8 @@ object JSHeaders {
 
 method: Method.GET, Method.POST, etc.
 uri: representation of the request URI
-httpVersion: the HTTP version
+httpVersion: the HTTP version //not used in lambda-http4s
 headers: collection of Headers
 body: fs2.Stream[F, Byte] defining the body of the request
-attributes: Immutable Map used for carrying additional information in a type safe fashion */
+attributes: Immutable Map used for carrying additional information in a type safe fashion //not used in lambda-http4s
+*/

--- a/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
@@ -110,13 +110,3 @@ object JSReadableStream {
 
   object Syntax {}
 }
-
-/* Parameters
-
-method: Method.GET, Method.POST, etc.
-uri: representation of the request URI
-httpVersion: the HTTP version //not used in lambda-http4s
-headers: collection of Headers
-body: fs2.Stream[F, Byte] defining the body of the request
-attributes: Immutable Map used for carrying additional information in a type safe fashion //not used in lambda-http4s
-*/

--- a/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
@@ -36,7 +36,7 @@ private[functions] trait JSRequest extends js.Object {
 @js.native
 private[functions] trait JSHeaders extends js.Object {
   def get(name: String): js.UndefOr[String] = js.native
-  def keys(): js.Iterator[String] = js.native 
+  def keys(): js.Iterator[String] = js.native
 }
 
 @js.native
@@ -63,7 +63,7 @@ object JSHeaders {
     val itr = h.keys()
     var entity = itr.next()
 
-    while(!entity.done) {
+    while (!entity.done) {
       builder.addOne(entity.value)
       entity = itr.next()
     }
@@ -72,27 +72,29 @@ object JSHeaders {
   }
 
   object Syntax {
-    //syntax for method like calls???
+    // syntax for method like calls???
   }
 }
 
 object JSReadableStream {
-  private[functions] def toFs2[F[_]: Async](streamOption: js.UndefOr[JSReadableStream]): Stream[F, Byte] = {
+  private[functions] def toFs2[F[_]: Async](
+      streamOption: js.UndefOr[JSReadableStream]): Stream[F, Byte] = {
     streamOption.toOption match {
       case None => Stream.empty
       case Some(null) => Stream.empty
       case Some(stream) => {
-        Stream.eval(Async[F].delay(stream.getReader())).flatMap{ reader => 
+        Stream.eval(Async[F].delay(stream.getReader())).flatMap { reader =>
           def nextChunk = {
-            Async[F].fromPromise(Async[F].delay(reader.read())).map{ read => 
-              if(read.done) {
+            Async[F].fromPromise(Async[F].delay(reader.read())).map { read =>
+              if (read.done) {
                 None
               } else {
-                val chunk = read.value
+                val chunk = read
+                  .value
                   .toOption
                   .map(arr => Chunk.array[Byte](toByteArray(arr)))
                   .getOrElse(Chunk.empty[Byte])
-                  
+
                 Some(chunk)
               }
             }
@@ -108,12 +110,12 @@ object JSReadableStream {
     }
   }
 
-  private def toByteArray(array: Uint8Array): Array[Byte] = { 
+  private def toByteArray(array: Uint8Array): Array[Byte] = {
     val builder = Array.newBuilder[Byte]
     val length = array.length
     var index = 0
 
-    while(index != length) {
+    while (index != length) {
       builder.addOne(array(index).toByte)
       index = index + 1
     }

--- a/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/facade/JSRequest.scala
@@ -6,11 +6,8 @@ import scala.scalajs.js.typedarray.Uint8Array
 import fs2.Stream
 import fs2.Chunk
 
-//import cats.effect.IO
 import cats.effect.kernel.Async
 import cats.syntax.all._
-
-//may want to change to requestFacade.., think it over
 
 @js.native
 trait JSRequest extends js.Object {

--- a/azure-functions/js/src/main/scala/feral/functions/util/AppConfig.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/AppConfig.scala
@@ -1,0 +1,59 @@
+package feral.functions.util
+
+import AppConfig._
+import scala.scalajs.js
+import feral.functions.facade.JSRequest
+import feral.functions.facade.InvocationContext
+
+final case class AppConfig(
+    methods: List[HttpMethod],
+    authLevel: AuthLevel,
+    route: AzureRoute,
+    handlerFn: HandlerFnT) {
+  def toJS: js.Object = {
+    js.Dynamic
+      .literal(
+        methods = methodsToJS(methods),
+        authLevel = authLevel.value,
+        route = route.value,
+        handler = handlerFn
+      )
+  }
+}
+
+object AppConfig {
+  sealed trait HttpMethod {
+    def value: String = {
+      this match {
+        case Get => "GET"
+        case Post => "POST"
+        case Put => "PUT"
+        case Patch => "PATCH"
+        case Delete => "DELETE"
+      }
+    }
+  }
+  case object Get extends HttpMethod
+  case object Post extends HttpMethod
+  case object Put extends HttpMethod
+  case object Patch extends HttpMethod
+  case object Delete extends HttpMethod
+
+  def methodsToJS(list: List[HttpMethod]): js.Array[String] = {
+    val dList = list.distinct.map(_.value)
+    js.Array(dList: _*)
+  }
+
+  case class AuthLevel(value: String)
+  val anonymous: AuthLevel = AuthLevel("anonymous")
+  // add more?
+
+  case class AzureRoute(value: String)
+  val catchAll: AzureRoute = AzureRoute("{*path}")
+  // add more?
+
+  type HandlerFnT = js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]]
+
+  def buildDefaultConfig(handlerFn: HandlerFnT) =
+    AppConfig(List(Get, Post, Put, Patch, Delete), anonymous, catchAll, handlerFn)
+}

--- a/azure-functions/js/src/main/scala/feral/functions/util/AppConfig.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/AppConfig.scala
@@ -1,7 +1,25 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.functions.util
 
 import AppConfig._
+
 import scala.scalajs.js
+
 import feral.functions.facade.JSRequest
 import feral.functions.facade.InvocationContext
 
@@ -10,7 +28,7 @@ final case class AppConfig(
     authLevel: AuthLevel,
     route: AzureRoute,
     handlerFn: HandlerFnT) {
-  def toJS: js.Object = {
+  private[functions] def toJS: js.Object = {
     js.Dynamic
       .literal(
         methods = methodsToJS(methods),
@@ -23,7 +41,7 @@ final case class AppConfig(
 
 object AppConfig {
   sealed trait HttpMethod {
-    def value: String = {
+    private[functions] def value: String = {
       this match {
         case Get => "GET"
         case Post => "POST"
@@ -39,7 +57,7 @@ object AppConfig {
   case object Patch extends HttpMethod
   case object Delete extends HttpMethod
 
-  def methodsToJS(list: List[HttpMethod]): js.Array[String] = {
+  private def methodsToJS(list: List[HttpMethod]): js.Array[String] = {
     val dList = list.distinct.map(_.value)
     js.Array(dList: _*)
   }
@@ -54,6 +72,6 @@ object AppConfig {
 
   type HandlerFnT = js.Function2[JSRequest, InvocationContext, js.Promise[js.UndefOr[js.Any]]]
 
-  def buildDefaultConfig(handlerFn: HandlerFnT) =
+  private[functions] def buildDefaultConfig(handlerFn: HandlerFnT) =
     AppConfig(List(Get, Post, Put, Patch, Delete), anonymous, catchAll, handlerFn)
 }

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -5,6 +5,7 @@ import org.http4s.Method
 import org.http4s.Uri
 import org.http4s.Header
 import org.http4s.Headers
+import org.http4s.Response
 
 import feral.functions.facade.JSRequest
 import feral.functions.facade.JSHeaders
@@ -14,10 +15,11 @@ import cats.syntax.all._
 
 import org.typelevel.ci.CIString
 
-
+import scala.scalajs.js
+//import scala.scalajs.js.annotation._
 
 object Parser {
-  def decodeRequest[F[_]: Concurrent](request: JSRequest): F[Request[F]] = 
+  def decodeRequest[F[_]: Concurrent](request: JSRequest): F[Request[F]] = {
     for {
       method <- Method.fromString(request.method).liftTo[F]
       uri <- Uri.fromString(request.url).liftTo[F]
@@ -34,4 +36,31 @@ object Parser {
       uri = uri,
       headers = headers
     )
+  }
+
+  def encodeResponse[F[_]: Concurrent](response: Response[F]): F[js.Any] = {
+    val headersList = ("TEST", "value") :: response.headers.headers.map(h => (h.name.toString, h.value)) 
+    val headers = js.Dictionary(headersList:_*)
+
+    //val body = response.body //need to figure this out later
+
+    val responseEncoded: js.Any = js
+      .Dynamic
+      .literal(
+        status = response.status.code,
+        headers = headers,
+        body = "Body Not Parsed!!!"
+      )
+
+    // val resp: js.Any =
+    //     js.Dynamic
+    //       .literal(
+    //         status = 200,
+    //         body = "payload",
+    //         headers = js.Dynamic.literal("content-type" -> "text/plain")
+    //       )
+
+    responseEncoded.pure[F]
+    //resp.pure[F]
+  }
 }

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -1,0 +1,5 @@
+package feral.functions.util
+
+object Parser {
+  //def decodeRequest[F[_]](request: JSRequest)
+}

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -10,7 +10,6 @@ import org.http4s.Response
 import feral.functions.facade.JSRequest
 import feral.functions.facade.JSHeaders
 
-//import cats.effect.kernel.Concurrent
 import cats.effect.kernel.Async
 import cats.syntax.all._
 import cats.effect.syntax.all._
@@ -19,11 +18,9 @@ import org.typelevel.ci.CIString
 
 import scala.scalajs.js
 import feral.functions.facade.JSReadableStream
-//import scala.scalajs.js.annotation._
 
 import fs2.Stream
 import cats.effect.std.Dispatcher
-//import fs2.Chunk
 
 import StreamUtil._
 import cats.effect.std.Queue
@@ -44,12 +41,11 @@ object Parser {
 
         Headers(builder.result())
       }
-      // body = JSReadableStream.toFs2[F](request.body) //need to use generic type parameter in tofs2
     } yield Request[F](
       method = method,
       uri = uri,
       headers = headers,
-      body = body // need to convert into Entity
+      body = body 
     )
   }
 

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -98,12 +98,12 @@ object Parser {
       .newInstance(js.Dynamic.global.ReadableStream)(
         js.Dynamic
           .literal(
-            start = (controller: js.Dynamic) => { /*NoOp*/ },
+            start = (_: js.Dynamic) => { /*NoOp*/ },
             pull = (controller: js.Dynamic) => {
               val effect = createPullEffect[F](controller, q)
               dispatcher.unsafeToPromise(effect)
             },
-            cancel = (reason: js.UndefOr[js.Any]) => {
+            cancel = (_: js.UndefOr[js.Any]) => {
               dispatcher.unsafeToPromise(streamFiber.cancel)
             }
           )

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.functions.util
 
 import org.http4s.Request
@@ -9,25 +25,26 @@ import org.http4s.Response
 
 import feral.functions.facade.JSRequest
 import feral.functions.facade.JSHeaders
+import feral.functions.facade.JSReadableStream
+
+import cats.syntax.all._
 
 import cats.effect.kernel.Async
-import cats.syntax.all._
 import cats.effect.syntax.all._
+import cats.effect.std.Queue
+import cats.effect.kernel.Fiber
+import cats.effect.std.Dispatcher
 
 import org.typelevel.ci.CIString
 
 import scala.scalajs.js
-import feral.functions.facade.JSReadableStream
 
 import fs2.Stream
-import cats.effect.std.Dispatcher
 
 import StreamUtil._
-import cats.effect.std.Queue
-import cats.effect.kernel.Fiber
 
 object Parser {
-  def decodeRequest[F[_]: Async](request: JSRequest): F[Request[F]] = {
+  private[functions] def decodeRequest[F[_]: Async](request: JSRequest): F[Request[F]] = {
     for {
       method <- Method.fromString(request.method).liftTo[F]
       uri <- Uri.fromString(request.url).liftTo[F]
@@ -49,7 +66,7 @@ object Parser {
     )
   }
 
-  def encodeResponse[F[_]: Async](
+  private[functions] def encodeResponse[F[_]: Async](
       response: Response[F],
       dispatcher: Dispatcher[F],
       qBound: Int): F[js.Any] = {
@@ -68,7 +85,7 @@ object Parser {
     }
   }
 
-  def createStreamFiber[F[_]: Async](
+  private def createStreamFiber[F[_]: Async](
       stream: Stream[F, Byte],
       q: Queue[F, StreamData]): F[Fiber[F, Throwable, Unit]] = {
     stream
@@ -84,12 +101,12 @@ object Parser {
       .start
   }
 
-  def createHeaders[F[_]: Async](responseHeaders: Headers): F[js.Dictionary[String]] = {
+  private def createHeaders[F[_]: Async](responseHeaders: Headers): F[js.Dictionary[String]] = {
     val headersList = responseHeaders.headers.map(h => (h.name.toString, h.value))
     js.Dictionary(headersList: _*).pure[F]
   }
 
-  def createBodyStream[F[_]: Async](
+  private def createBodyStream[F[_]: Async](
       q: Queue[F, StreamData],
       streamFiber: Fiber[F, Throwable, Unit],
       dispatcher: Dispatcher[F]): F[js.Any] = {
@@ -112,7 +129,7 @@ object Parser {
     readableStream.pure[F]
   }
 
-  def createPullEffect[F[_]: Async](
+  private def createPullEffect[F[_]: Async](
       controller: js.Dynamic,
       q: Queue[F, StreamData]): F[Unit] = {
     q.take.flatMap {

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -10,7 +10,7 @@ import org.http4s.Response
 import feral.functions.facade.JSRequest
 import feral.functions.facade.JSHeaders
 
-import cats.effect.kernel.Concurrent
+//import cats.effect.kernel.Concurrent
 import cats.effect.kernel.Async
 import cats.syntax.all._
 
@@ -61,18 +61,10 @@ object Parser {
         body = toReadableStream[F](response.body, dispatcher)//response.body.through(fs2.text.utf8.decode).compile.toString
       )
 
-    // val resp: js.Any =
-    //     js.Dynamic
-    //       .literal(
-    //         status = 200,
-    //         body = "payload",
-    //         headers = js.Dynamic.literal("content-type" -> "text/plain")
-    //       )
-
     responseEncoded.pure[F]
-    // resp.pure[F]
   }
 
+  //probably want to change this to implement pull and cancel, this may work but is not the best impl
   private def toReadableStream[F[_]: Async](
       stream: Stream[F, Byte],
       dispatcher: Dispatcher[F]): js.Any = {

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -13,6 +13,7 @@ import feral.functions.facade.JSHeaders
 //import cats.effect.kernel.Concurrent
 import cats.effect.kernel.Async
 import cats.syntax.all._
+import cats.effect.syntax.all._
 
 import org.typelevel.ci.CIString
 
@@ -22,6 +23,11 @@ import feral.functions.facade.JSReadableStream
 
 import fs2.Stream
 import cats.effect.std.Dispatcher
+//import fs2.Chunk
+
+import StreamUtil._
+import cats.effect.std.Queue
+import cats.effect.kernel.Fiber
 
 object Parser {
   def decodeRequest[F[_]: Async](request: JSRequest): F[Request[F]] = {
@@ -47,7 +53,9 @@ object Parser {
     )
   }
 
-  def encodeResponse[F[_]: Async](response: Response[F], dispatcher: Dispatcher[F]): F[js.Any] = {
+  def encodeResponse[F[_]: Async](
+      response: Response[F],
+      dispatcher: Dispatcher[F]): F[js.Any] = {
     val headersList = response.headers.headers.map(h => (h.name.toString, h.value))
     val headers = js.Dictionary(headersList: _*)
 
@@ -58,35 +66,128 @@ object Parser {
       .literal(
         status = response.status.code,
         headers = headers,
-        body = toReadableStream[F](response.body, dispatcher)//response.body.through(fs2.text.utf8.decode).compile.toString
+        body = toReadableStream[F](
+          response.body,
+          dispatcher
+        ) // response.body.through(fs2.text.utf8.decode).compile.toString
       )
 
     responseEncoded.pure[F]
   }
 
-  //probably want to change this to implement pull and cancel, this may work but is not the best impl
+  // probably want to change this to implement pull and cancel, this may work but is not the best impl
   private def toReadableStream[F[_]: Async](
       stream: Stream[F, Byte],
       dispatcher: Dispatcher[F]): js.Any = {
-    js.Dynamic.newInstance(js.Dynamic.global.ReadableStream)(
-      js.Dynamic.literal(
-        start = (controller: js.Dynamic) => {
-          val io = {
-            stream.chunks.evalMap { chunk =>
-              Async[F].delay {
-                val array = new js.typedarray.Uint8Array(chunk.size) 
-                chunk.toArray.zipWithIndex.foreach{ case (byte, index) => array(index) = byte }
-                controller.enqueue(array)
+    js.Dynamic
+      .newInstance(js.Dynamic.global.ReadableStream)(
+        js.Dynamic
+          .literal(
+            start = (controller: js.Dynamic) => {
+              val io = {
+                stream
+                  .chunks
+                  .evalMap { chunk =>
+                    Async[F].delay {
+                      val array = new js.typedarray.Uint8Array(chunk.size)
+                      chunk.toArray.zipWithIndex.foreach {
+                        case (byte, index) => array(index) = byte
+                      }
+                      controller.enqueue(array)
+                    }.void
+                  }
+                  .onFinalize(Async[F].delay(controller.close()).void)
+                  .compile
+                  .drain
               }
-              .void
+              dispatcher.unsafeToPromise(io)
             }
-            .onFinalize(Async[F].delay(controller.close()).void)
-            .compile
-            .drain
-          }
-          dispatcher.unsafeToPromise(io)
-        }
+          )
       )
-    )
+  }
+
+  def encodeResponseV2[F[_]: Async](
+      response: Response[F],
+      dispatcher: Dispatcher[F],
+      qBound: Int): F[js.Any] = {
+    for {
+      q <- Queue.bounded[F, StreamData](qBound)
+      streamFiber <- createStreamFiber[F](response.body, q)
+      headers <- createHeaders[F](response.headers)
+      body <- createBodyStream[F](q, streamFiber, dispatcher)
+    } yield {
+      js.Dynamic
+        .literal(
+          status = response.status.code,
+          headers = headers,
+          body = body
+        )
+    }
+  }
+
+  def createStreamFiber[F[_]: Async](
+      stream: Stream[F, Byte],
+      q: Queue[F, StreamData]): F[Fiber[F, Throwable, Unit]] = {
+    stream
+      .chunks
+      .evalMap(chunk => q.offer(Data(chunk)))
+      .compile
+      .drain
+      .attempt
+      .flatMap {
+        case Right(_) => q.offer(End)
+        case Left(e) => q.offer(Error(e))
+      }
+      .start
+  }
+
+  def createHeaders[F[_]: Async](responseHeaders: Headers): F[js.Dictionary[String]] = {
+    val headersList = responseHeaders.headers.map(h => (h.name.toString, h.value))
+    js.Dictionary(headersList: _*).pure[F]
+  }
+
+  def createBodyStream[F[_]: Async](
+      q: Queue[F, StreamData],
+      streamFiber: Fiber[F, Throwable, Unit],
+      dispatcher: Dispatcher[F]): F[js.Any] = {
+    val readableStream: js.Any = js
+      .Dynamic
+      .newInstance(js.Dynamic.global.ReadableStream)(
+        js.Dynamic
+          .literal(
+            start = (controller: js.Dynamic) => { /*NoOp*/ },
+            pull = (controller: js.Dynamic) => {
+              val effect = createPullEffect[F](controller, q)
+              dispatcher.unsafeToPromise(effect)
+            },
+            cancel = (reason: js.UndefOr[js.Any]) => {
+              dispatcher.unsafeToPromise(streamFiber.cancel)
+            }
+          )
+      )
+
+    readableStream.pure[F]
+  }
+
+  def createPullEffect[F[_]: Async](
+      controller: js.Dynamic,
+      q: Queue[F, StreamData]): F[Unit] = {
+    q.take.flatMap {
+      case Error(e) => {
+        Async[F].delay(controller.error(e.getMessage)).void
+      }
+      case End => {
+        Async[F].delay(controller.close()).void
+      }
+      case Data(chunk) => {
+        Async[F].delay {
+          val array = new js.typedarray.Uint8Array(chunk.size)
+          chunk.toArray.zipWithIndex.foreach {
+            case (byte, index) => array(index) = (byte & 0xff).toShort
+          }
+          controller.enqueue(array)
+        }.void
+      }
+    }
   }
 }

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -11,18 +11,21 @@ import feral.functions.facade.JSRequest
 import feral.functions.facade.JSHeaders
 
 import cats.effect.kernel.Concurrent
+import cats.effect.kernel.Async
 import cats.syntax.all._
 
 import org.typelevel.ci.CIString
 
 import scala.scalajs.js
+import feral.functions.facade.JSReadableStream
 //import scala.scalajs.js.annotation._
 
 object Parser {
-  def decodeRequest[F[_]: Concurrent](request: JSRequest): F[Request[F]] = {
+  def decodeRequest[F[_]: Async](request: JSRequest): F[Request[F]] = {
     for {
       method <- Method.fromString(request.method).liftTo[F]
       uri <- Uri.fromString(request.url).liftTo[F]
+      body = JSReadableStream.toFs2[F](request.body)
       headers = {
         val builder = List.newBuilder[Header.Raw]
         val keys = JSHeaders.keyList(request.headers)
@@ -31,15 +34,17 @@ object Parser {
 
         Headers(builder.result())
       }
+      //body = JSReadableStream.toFs2[F](request.body) //need to use generic type parameter in tofs2
     } yield Request[F](
       method = method,
       uri = uri,
-      headers = headers
+      headers = headers,
+      body = body // need to convert into Entity
     )
   }
 
   def encodeResponse[F[_]: Concurrent](response: Response[F]): F[js.Any] = {
-    val headersList = ("TEST", "value") :: response.headers.headers.map(h => (h.name.toString, h.value)) 
+    val headersList = response.headers.headers.map(h => (h.name.toString, h.value)) 
     val headers = js.Dictionary(headersList:_*)
 
     //val body = response.body //need to figure this out later
@@ -49,7 +54,7 @@ object Parser {
       .literal(
         status = response.status.code,
         headers = headers,
-        body = "Body Not Parsed!!!"
+        body = response.body.through(fs2.text.utf8.decode).compile.toString
       )
 
     // val resp: js.Any =

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -1,5 +1,37 @@
 package feral.functions.util
 
+import org.http4s.Request
+import org.http4s.Method
+import org.http4s.Uri
+import org.http4s.Header
+import org.http4s.Headers
+
+import feral.functions.facade.JSRequest
+import feral.functions.facade.JSHeaders
+
+import cats.effect.kernel.Concurrent
+import cats.syntax.all._
+
+import org.typelevel.ci.CIString
+
+
+
 object Parser {
-  //def decodeRequest[F[_]](request: JSRequest)
+  def decodeRequest[F[_]: Concurrent](request: JSRequest): F[Request[F]] = 
+    for {
+      method <- Method.fromString(request.method).liftTo[F]
+      uri <- Uri.fromString(request.url).liftTo[F]
+      headers = {
+        val builder = List.newBuilder[Header.Raw]
+        val keys = JSHeaders.keyList(request.headers)
+
+        keys.foreach(k => builder.addOne(Header.Raw(CIString(k), request.headers.get(k).getOrElse(""))))
+
+        Headers(builder.result())
+      }
+    } yield Request[F](
+      method = method,
+      uri = uri,
+      headers = headers
+    )
 }

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -20,6 +20,9 @@ import scala.scalajs.js
 import feral.functions.facade.JSReadableStream
 //import scala.scalajs.js.annotation._
 
+import fs2.Stream
+import cats.effect.std.Dispatcher
+
 object Parser {
   def decodeRequest[F[_]: Async](request: JSRequest): F[Request[F]] = {
     for {
@@ -30,11 +33,12 @@ object Parser {
         val builder = List.newBuilder[Header.Raw]
         val keys = JSHeaders.keyList(request.headers)
 
-        keys.foreach(k => builder.addOne(Header.Raw(CIString(k), request.headers.get(k).getOrElse(""))))
+        keys.foreach(k =>
+          builder.addOne(Header.Raw(CIString(k), request.headers.get(k).getOrElse(""))))
 
         Headers(builder.result())
       }
-      //body = JSReadableStream.toFs2[F](request.body) //need to use generic type parameter in tofs2
+      // body = JSReadableStream.toFs2[F](request.body) //need to use generic type parameter in tofs2
     } yield Request[F](
       method = method,
       uri = uri,
@@ -43,18 +47,18 @@ object Parser {
     )
   }
 
-  def encodeResponse[F[_]: Concurrent](response: Response[F]): F[js.Any] = {
-    val headersList = response.headers.headers.map(h => (h.name.toString, h.value)) 
-    val headers = js.Dictionary(headersList:_*)
+  def encodeResponse[F[_]: Async](response: Response[F], dispatcher: Dispatcher[F]): F[js.Any] = {
+    val headersList = response.headers.headers.map(h => (h.name.toString, h.value))
+    val headers = js.Dictionary(headersList: _*)
 
-    //val body = response.body //need to figure this out later
+    // val body = response.body //need to figure this out later
 
     val responseEncoded: js.Any = js
       .Dynamic
       .literal(
         status = response.status.code,
         headers = headers,
-        body = response.body.through(fs2.text.utf8.decode).compile.toString
+        body = toReadableStream[F](response.body, dispatcher)//response.body.through(fs2.text.utf8.decode).compile.toString
       )
 
     // val resp: js.Any =
@@ -66,6 +70,31 @@ object Parser {
     //       )
 
     responseEncoded.pure[F]
-    //resp.pure[F]
+    // resp.pure[F]
+  }
+
+  private def toReadableStream[F[_]: Async](
+      stream: Stream[F, Byte],
+      dispatcher: Dispatcher[F]): js.Any = {
+    js.Dynamic.newInstance(js.Dynamic.global.ReadableStream)(
+      js.Dynamic.literal(
+        start = (controller: js.Dynamic) => {
+          val io = {
+            stream.chunks.evalMap { chunk =>
+              Async[F].delay {
+                val array = new js.typedarray.Uint8Array(chunk.size) 
+                chunk.toArray.zipWithIndex.foreach{ case (byte, index) => array(index) = byte }
+                controller.enqueue(array)
+              }
+              .void
+            }
+            .onFinalize(Async[F].delay(controller.close()).void)
+            .compile
+            .drain
+          }
+          dispatcher.unsafeToPromise(io)
+        }
+      )
+    )
   }
 }

--- a/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/Parser.scala
@@ -55,59 +55,6 @@ object Parser {
 
   def encodeResponse[F[_]: Async](
       response: Response[F],
-      dispatcher: Dispatcher[F]): F[js.Any] = {
-    val headersList = response.headers.headers.map(h => (h.name.toString, h.value))
-    val headers = js.Dictionary(headersList: _*)
-
-    // val body = response.body //need to figure this out later
-
-    val responseEncoded: js.Any = js
-      .Dynamic
-      .literal(
-        status = response.status.code,
-        headers = headers,
-        body = toReadableStream[F](
-          response.body,
-          dispatcher
-        ) // response.body.through(fs2.text.utf8.decode).compile.toString
-      )
-
-    responseEncoded.pure[F]
-  }
-
-  // probably want to change this to implement pull and cancel, this may work but is not the best impl
-  private def toReadableStream[F[_]: Async](
-      stream: Stream[F, Byte],
-      dispatcher: Dispatcher[F]): js.Any = {
-    js.Dynamic
-      .newInstance(js.Dynamic.global.ReadableStream)(
-        js.Dynamic
-          .literal(
-            start = (controller: js.Dynamic) => {
-              val io = {
-                stream
-                  .chunks
-                  .evalMap { chunk =>
-                    Async[F].delay {
-                      val array = new js.typedarray.Uint8Array(chunk.size)
-                      chunk.toArray.zipWithIndex.foreach {
-                        case (byte, index) => array(index) = byte
-                      }
-                      controller.enqueue(array)
-                    }.void
-                  }
-                  .onFinalize(Async[F].delay(controller.close()).void)
-                  .compile
-                  .drain
-              }
-              dispatcher.unsafeToPromise(io)
-            }
-          )
-      )
-  }
-
-  def encodeResponseV2[F[_]: Async](
-      response: Response[F],
       dispatcher: Dispatcher[F],
       qBound: Int): F[js.Any] = {
     for {

--- a/azure-functions/js/src/main/scala/feral/functions/util/StreamUtil.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/StreamUtil.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Typelevel
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package feral.functions.util
 
 import fs2.Chunk

--- a/azure-functions/js/src/main/scala/feral/functions/util/StreamUtil.scala
+++ b/azure-functions/js/src/main/scala/feral/functions/util/StreamUtil.scala
@@ -1,0 +1,10 @@
+package feral.functions.util
+
+import fs2.Chunk
+
+object StreamUtil {
+  sealed trait StreamData
+  final case class Data(chunk: Chunk[Byte]) extends StreamData
+  case object End extends StreamData
+  final case class Error(e: Throwable) extends StreamData
+}

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ name := "feral"
 
 ThisBuild / tlBaseVersion := "0.3"
 ThisBuild / startYear := Some(2021)
-ThisBuild / isSnapshot := true
 
 ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ name := "feral"
 
 ThisBuild / tlBaseVersion := "0.3"
 ThisBuild / startYear := Some(2021)
+ThisBuild / isSnapshot := true
 
 ThisBuild / developers := List(
   tlGitHubDev("armanbilge", "Arman Bilge"),
@@ -76,6 +77,7 @@ lazy val root =
       lambdaHttp4s,
       lambdaCloudFormationCustomResource,
       googleCloudHttp4s,
+      azureFunctions,
       examples,
       unidocs
     )
@@ -276,15 +278,18 @@ lazy val azureFunctions = crossProject(JSPlatform, JVMPlatform)
   .in(file("azure-functions"))
   .settings(
     name := "azure-functions", 
-    libraryDependencies ++= Seq()
-  )
-  .settings(commonSettings)
-  .jsSettings(
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
       "io.circe" %%% "circe-scodec" % circeVersion,
       "org.http4s" %%% "http4s-server" % http4sVersion
-    )
+    ),
+    tlVersionIntroduced := List("2.13", "3").map(_ -> "0.3.1").toMap
+  )
+  .settings(commonSettings)
+  .jsSettings(
+    libraryDependencies ++= Seq(
+    ),
+    scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
   )
   .jvmSettings(
     Test / fork := true,

--- a/build.sbt
+++ b/build.sbt
@@ -280,7 +280,11 @@ lazy val azureFunctions = crossProject(JSPlatform, JVMPlatform)
   )
   .settings(commonSettings)
   .jsSettings(
-    libraryDependencies ++= Seq()
+    libraryDependencies ++= Seq(
+      "org.typelevel" %%% "cats-effect" % catsEffectVersion,
+      "io.circe" %%% "circe-scodec" % circeVersion,
+      "org.http4s" %%% "http4s-server" % http4sVersion
+    )
   )
   .jvmSettings(
     Test / fork := true,

--- a/build.sbt
+++ b/build.sbt
@@ -281,7 +281,8 @@ lazy val azureFunctions = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "cats-effect" % catsEffectVersion,
       "io.circe" %%% "circe-scodec" % circeVersion,
-      "org.http4s" %%% "http4s-server" % http4sVersion
+      "org.http4s" %%% "http4s-server" % http4sVersion,
+      "co.fs2" %%% "fs2-io" % fs2Version
     ),
     tlVersionIntroduced := List("2.13", "3").map(_ -> "0.3.1").toMap
   )

--- a/build.sbt
+++ b/build.sbt
@@ -271,3 +271,18 @@ lazy val googleCloudHttp4s = crossProject(JSPlatform, JVMPlatform)
       "co.fs2" %%% "fs2-io" % fs2Version
     )
   )
+
+lazy val azureFunctions = crossProject(JSPlatform, JVMPlatform)
+  .in(file("azure-functions"))
+  .settings(
+    name := "azure-functions", 
+    libraryDependencies ++= Seq()
+  )
+  .settings(commonSettings)
+  .jsSettings(
+    libraryDependencies ++= Seq()
+  )
+  .jvmSettings(
+    Test / fork := true,
+    libraryDependencies ++= Seq()
+  )


### PR DESCRIPTION
Added support for creating Azure Function Apps with Http4s. 

Simple usage example:
```scala
import org.http4s.HttpApp
import org.http4s.HttpRoutes
import org.http4s.dsl.io._

import cats.effect.IO
import cats.effect.kernel.Resource

import feral.functions.IOAzureHttpFunction
import feral.functions.facade.Context

object feralEX extends IOAzureHttpFunction {
  override def handler: Context => Resource[IO,HttpApp[IO]] = {
    context => {
      val app = HttpRoutes
        .of[IO] {
          case GET -> Root / "api" / "hello" / name =>
            context.log("Log Message.")
            Ok(s"Hello, $name.")
        }
        .orNotFound

      Resource.pure(app)
    }
  }
}
```

Azure resources:

- [Azure development guide](https://docs.azure.cn/en-us/azure-functions/functions-reference-node?tabs=javascript%2Cwindows%2Cazure-cli&pivots=nodejs-model-v4#invocation-context)
